### PR TITLE
Add ability to specify checkpoint step frequency.

### DIFF
--- a/tf/configs/example.yaml
+++ b/tf/configs/example.yaml
@@ -16,6 +16,7 @@ training:
     batch_size: 2048                   # training batch
     test_steps: 2000                   # eval test set values after this many steps
     total_steps: 140000                # terminate after these steps
+    # checkpoint_steps: 10000          # optional frequency for checkpointing before finish
     shuffle_size: 524288               # size of the shuffle buffer
     lr_values:                         # list of learning rates
         - 0.02

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -253,7 +253,8 @@ class TFProcess:
         if steps % self.cfg['training']['test_steps'] == 0 or steps % self.cfg['training']['total_steps'] == 0:
             self.calculate_test_summaries(test_batches, steps)
 
-        if steps % self.cfg['training']['total_steps'] == 0:
+        if steps % self.cfg['training']['total_steps'] == 0 or (
+                'checkpoint_steps' in self.cfg['training'] and steps % self.cfg['training']['checkpoint_steps'] == 0):
             path = os.path.join(self.root_dir, self.cfg['name'])
             save_path = self.saver.save(self.session, path, global_step=steps)
             print("Model saved in file: {}".format(save_path))

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -253,6 +253,7 @@ class TFProcess:
         if steps % self.cfg['training']['test_steps'] == 0 or steps % self.cfg['training']['total_steps'] == 0:
             self.calculate_test_summaries(test_batches, steps)
 
+        # Save session and weights at end, and also optionally every 'checkpoint_steps'.
         if steps % self.cfg['training']['total_steps'] == 0 or (
                 'checkpoint_steps' in self.cfg['training'] and steps % self.cfg['training']['checkpoint_steps'] == 0):
             path = os.path.join(self.root_dir, self.cfg['name'])


### PR DESCRIPTION
When doing a long bootstrap rather than an incremental train, checkpointing in the middle has significant value. So optionally add that ability back rather than only checkpointing at the end.