### PR TITLE
Move process loop into tfprocess.py to better handle resume.

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -186,6 +186,14 @@ class TFProcess:
         print("Restoring from {0}".format(file))
         self.saver.restore(self.session, file)
 
+    def process_loop(self, batch_size, test_batches):
+        # Get the initial steps value in case this is a resume from a step count
+        # which is not a multiple of total_steps.
+        steps = tf.train.global_step(self.session, self.global_step)
+        total_steps = self.cfg['training']['total_steps']
+        for _ in range(steps % total_steps, total_steps):
+            self.process(batch_size, test_batches)
+
     def process(self, batch_size, test_batches):
         if not self.time_start:
             self.time_start = time.time()

--- a/tf/train.py
+++ b/tf/train.py
@@ -134,8 +134,7 @@ def main(cmd):
     num_evals = num_test*10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
-    for _ in range(cfg['training']['total_steps']):
-        tfprocess.process(ChunkParser.BATCH_SIZE, num_evals)
+    tfprocess.process_loop(ChunkParser.BATHC_SIZE, num_evals)
 
     tfprocess.save_leelaz_weights(cmd.output)
 

--- a/tf/train.py
+++ b/tf/train.py
@@ -134,7 +134,7 @@ def main(cmd):
     num_evals = num_test*10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
-    tfprocess.process_loop(ChunkParser.BATHC_SIZE, num_evals)
+    tfprocess.process_loop(ChunkParser.BATCH_SIZE, num_evals)
 
     tfprocess.save_leelaz_weights(cmd.output)
 


### PR DESCRIPTION
If you resumed from part way through a total_steps count, it would still run for total_steps, which is definitely not ideal.
By moving the process_loop into tfprocess we can easily use the current step count to reduce the number of steps performed so the process will complete on a multiple of total_steps.