### PR TITLE
Experimental patch to disable history in training - not for merging

### DIFF
--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -168,6 +168,11 @@ class ChunkParser:
 
         # Unpack bit planes and cast to 32 bit float
         planes = np.unpackbits(np.frombuffer(planes, dtype=np.uint8)).astype(np.float32)
+
+        # Set planes 14-18 and 20-104 to zero
+        planes[896:1216] = 0
+        planes[1280:6656] = 0
+
         rule50_plane = (np.zeros(8*8, dtype=np.float32) + rule50_count) / 99
 
         # Concatenate all byteplanes. Make the last plane all 1's so the NN can

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -160,6 +160,11 @@ class TFProcess:
                     for i in range(len(new_weights[e])):
                         if (i%(num_inputs*9))//9 == rule50_input:
                             new_weights[e][i] = new_weights[e][i]*99
+                        # zero all history except pawns from the previous move (13 and 19 starting from 0)
+                        if 14 <= (i%(num_inputs*9))//9 <= 18:
+                            new_weights[e][i] = 0
+                        if 20 <= (i%(num_inputs*9))//9 <= 103:
+                            new_weights[e][i] = 0
 
                 # Convolution weights need a transpose
                 #


### PR DESCRIPTION
This is an experiment to clear history in training, both when importing a new weights file and when reading chunks. The only history retained is the previous pawn positions, for en passant capture detection.
Ideally this will allow training of new networks without any other history input that should be fully compatible with current clients.
WARNING: it has been very lightly tested.