### PR TITLE
initial new pipeline proposal

### DIFF
--- a/tf/start.sh
+++ b/tf/start.sh
@@ -37,7 +37,6 @@ do
     echo ""
 
     # prepare ramdisk
-    rm -rf $RAMDISK/{train,test}
     rsync -aq --delete-during $ROOT/split/{train,test} $RAMDISK
 
     # train all networks


### PR DESCRIPTION
This update adds the following features:
- utilize ramdisk
- train multiple networks on the same data
- permanent test/train split

It assumes that another script prepares the test/train split and that the underlying `train.py` script utilizes multigpu support in the future. Furthermore it assumes that yet another script will upload the correct network from `$NETDIR` to the server.

Please provide your feedback!