### PR TITLE
Replace 'NUM_STEPS_TRAIN' with a configurable value.

### DIFF
--- a/tf/configs/example.yaml
+++ b/tf/configs/example.yaml
@@ -15,6 +15,7 @@ dataset:
 training:
     batch_size: 2048                   # training batch
     test_steps: 2000                   # eval test set values after this many steps
+    train_avg_report_steps: 200        # training reports its average values after this many steps.
     total_steps: 140000                # terminate after these steps
     # checkpoint_steps: 10000          # optional frequency for checkpointing before finish
     shuffle_size: 524288               # size of the shuffle buffer


### PR DESCRIPTION
While testing for the new lc0 training run I decided on 2500 steps as a desired value for total_steps.  But this isn't a multiple of 200, which leaves a bit of an odd train value reporting structure.
By adding this configuration I can change the train average reporting interval up to 250.  Also added a fail safe to ensure we always report the train at the end rather than lose the data if the configured value is not aligned with the total_steps.