### PR TITLE
Add lock, allow split continuing, check file integrity

### DIFF
--- a/scripts/split.sh
+++ b/scripts/split.sh
@@ -79,12 +79,14 @@ process() {
 
   if [[ $file = training.*.gz ]]
   then
+    # check if the file already exists in the desired location
     if [ -f "$TESTDIR/$file" ] || [ -f "$TRAINDIR/$file" ]
     then
       echo -n "."
       return
     fi
 
+    # compute basic file integrity check
     size=$(zcat $dir/$file | wc -c)
     let rem="size % 8276"
     
@@ -94,6 +96,7 @@ process() {
       return
     fi
 
+    # new correct file, put in correct directory
     let "n++"
 
     id=$(echo $file | cut -d'.' -f 2)
@@ -110,14 +113,15 @@ process() {
 
     ln $dir/$file $target
 
+    # exceeding max buffer size, remove overhead
     if [ $n -gt $max ]
     then
       (
       flock -e 200
       ls -rt $TESTDIR | head -n $overhead_test | xargs -I{} rm -f $TESTDIR/{}
       ls -rt $TRAINDIR | head -n $overhead_train | xargs -I{} rm -f $TRAINDIR/{}
-      let "n -= $overhead"
       ) 200>$LC0LOCKFILE
+      let "n -= $overhead"
     fi
   fi
 }

--- a/scripts/split.sh
+++ b/scripts/split.sh
@@ -55,13 +55,13 @@ fi
 # clear test and train split dirs
 if [ ! -d "$TESTDIR" ] || [ ! -d "$TRAINDIR" ]
 then
-  rm -rf $TESTDIR $TRAINDIR
-  mkdir -vp $TESTDIR $TRAINDIR
+  rm -rf "$TESTDIR" "$TRAINDIR"
+  mkdir -vp "$TESTDIR" "$TRAINDIR"
 fi
 
 let n="$(ls $TESTDIR | wc -l) + $(ls $TRAINDIR | wc -l)"
 let overhead="$WINSIZE / 10"
-let max="$WINSIZE + $overhead"
+let max="$WINSIZE + $overhead + 100"
 overhead_train=$(echo "scale=1;($TRAINPCT / 100) * $overhead" | bc | cut -d'.' -f1)
 overhead_test=$(echo "scale=1;(1 - $TRAINPCT / 100) * $overhead" | bc | cut -d'.' -f1)
 

--- a/tf/start.sh
+++ b/tf/start.sh
@@ -17,6 +17,12 @@ then
   exit 1
 fi
 
+if [ -z "$LC0LOCKFILE" ]
+then
+  echo "env var LC0LOCKFILE not set"
+  exit 1
+fi
+
 game_num=$(cat $GAMEFILE)
 game_num=$((game_num + GAMES))
 file="training.${game_num}.gz"
@@ -37,7 +43,10 @@ do
     echo ""
 
     # prepare ramdisk
+    (
+    flock -e 200
     rsync -aq --delete-during $ROOT/split/{train,test} $RAMDISK
+    ) 200>$LC0LOCKFILE
 
     # train all networks
     for netarch in ${NETARCHS[@]}


### PR DESCRIPTION
Ok in hindsight I should've split into various commits, but this is what I implemented:
- allow continues when the `$TRAINDIR` and `$TESTDIR` exist
- implement exclusive lock on rsync from `start.sh` and file removal from `split.sh` through `flock`
- implement game file integrity by making sure that file size > 0 and file size is a multiple of 8276