### PR TITLE
track the LR

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -260,6 +260,7 @@ class TFProcess:
             train_summaries = tf.Summary(value=[
                 tf.Summary.Value(tag="Policy Loss", simple_value=avg_policy_loss),
                 tf.Summary.Value(tag="Reg term", simple_value=avg_reg_term),
+                tf.Summary.Value(tag="LR", simple_value=self.lr),
                 tf.Summary.Value(tag="MSE Loss", simple_value=avg_mse_loss)])
             self.train_writer.add_summary(train_summaries, steps)
             self.time_start = time_end


### PR DESCRIPTION
This extensive PR forces the current value for Learning Rate to be added to the TensorBoard logs.
This change can be added to an existing network with no additional work having to be done.