### PR TITLE
remove lr value sorting

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -105,7 +105,6 @@ class TFProcess:
 
         # Set adaptive learning rate during training
         self.cfg['training']['lr_boundaries'].sort()
-        self.cfg['training']['lr_values'].sort(reverse=True)
         self.lr = self.cfg['training']['lr_values'][0]
 
         # You need to change the learning rate here if you are training


### PR DESCRIPTION
I often forget to remove this line when doing a cyclical LR scheme. Also, if people aren't putting their values in the correct order they aren't doing it right and shouldn't rely on this to fix it.