### PR TITLE
Fix duplicate histogram summaries for same variable

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -134,6 +134,7 @@ class TFProcess:
             os.path.join(os.getcwd(), "leelalogs/{}-test".format(self.cfg['name'])), self.session.graph)
         self.train_writer = tf.summary.FileWriter(
             os.path.join(os.getcwd(), "leelalogs/{}-train".format(self.cfg['name'])), self.session.graph)
+        self.histograms = [tf.summary.histogram(weight.name, weight) for weight in self.weights]
 
         self.init = tf.global_variables_initializer()
         self.saver = tf.train.Saver()
@@ -303,8 +304,7 @@ class TFProcess:
             tf.Summary.Value(tag="Accuracy", simple_value=sum_accuracy),
             tf.Summary.Value(tag="Policy Loss", simple_value=sum_policy),
             tf.Summary.Value(tag="MSE Loss", simple_value=sum_mse)]).SerializeToString()
-        histograms = [tf.summary.histogram(weight.name, weight) for weight in self.weights]
-        test_summaries = tf.summary.merge([test_summaries] + histograms).eval(session=self.session)
+        test_summaries = tf.summary.merge([test_summaries] + self.histograms).eval(session=self.session)
         self.test_writer.add_summary(test_summaries, steps)
         print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\
             format(steps, sum_policy, sum_accuracy, sum_mse))


### PR DESCRIPTION
Currently, there are 6 similar copies of each variable in the histogram tab: e.g. `bn0/batch_normalization/beta_0`, `.../beta_0_1`, ..., `.../beta_0_5`. I believe that this is due to new histogram nodes being created every time calculate_test_summaries is called, which causes TensorBoard to try to rename them.
This PR changes it so that histogram nodes are only created once, thus TB should be able to reuse the summary nodes to make the histograms easier to view.

Again, I don't have things set-up properly to be able to test whether this actually works (but I think it should). Merging this PR shouldn't need a newly generated checkpoint unlike last time https://github.com/LeelaChessZero/lczero-training/pull/20.