### PR TITLE
Implement gradient accumulation

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -233,8 +233,10 @@ class TFProcess:
             self.avg_policy_loss.append(policy_loss)
             self.avg_mse_loss.append(mse_loss)
             self.avg_reg_term.append(reg_term)
+        # Gradients of batch splits are summed, not averaged like usual, so need to scale lr accordingly to correct for this.
+        corrected_lr = self.lr / batch_splits
         self.session.run(self.train_op,
-            feed_dict={self.learning_rate: self.lr / batch_splits, self.training: True, self.handle: self.train_handle})
+            feed_dict={self.learning_rate: corrected_lr, self.training: True, self.handle: self.train_handle})
 
         # Update steps since training should have incremented it.
         steps = tf.train.global_step(self.session, self.global_step)

--- a/tf/train.py
+++ b/tf/train.py
@@ -99,7 +99,13 @@ def main(cmd):
         test_chunks = chunks[num_train:]
 
     shuffle_size = cfg['training']['shuffle_size']
-    ChunkParser.BATCH_SIZE = cfg['training']['batch_size']
+    total_batch_size = cfg['training']['batch_size']
+    batch_splits = cfg['training'].get('num_batch_splits', 1)
+    if total_batch_size % batch_splits != 0:
+        raise ValueError('num_batch_splits must divide batch_size evenly')
+    split_batch_size = total_batch_size // batch_splits
+    # Load data with split batch size, which will be combined to the total batch size in tfprocess.
+    ChunkParser.BATCH_SIZE = split_batch_size
 
     root_dir = os.path.join(cfg['training']['path'], cfg['name'])
     if not os.path.exists(root_dir):
@@ -130,11 +136,12 @@ def main(cmd):
         tfprocess.restore(cp)
 
     # Sweeps through all test chunks statistically
-	# Assumes average of 10 samples per test game.
+    # Assumes average of 10 samples per test game.
+    # Evaluation result doesn't depend on batch size, so we can use split instead of total batch size.
     num_evals = num_test*10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
-    tfprocess.process_loop(ChunkParser.BATCH_SIZE, num_evals)
+    tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)
 
     tfprocess.save_leelaz_weights(cmd.output)
 

--- a/tf/train.py
+++ b/tf/train.py
@@ -137,7 +137,8 @@ def main(cmd):
 
     # Sweeps through all test chunks statistically
     # Assumes average of 10 samples per test game.
-    # Evaluation result doesn't depend on batch size, so we can use split instead of total batch size.
+    # For simplicity, testing can use the split batch size instead of total batch size.
+    # This does not affect results, because test results are simple averages that are independent of batch size.
     num_evals = num_test*10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 


### PR DESCRIPTION
This PR allows training with larger batches than GPU memory can store at once. This is done by splitting a batch into many smaller batches, of which the gradients are accumulated to perform one gradient update. The implementation is adapted from [this StackOverflow answer](https://stackoverflow.com/questions/46772685/how-to-accumulate-gradients-in-tensorflow).

By default, no splitting of batches is performed. If `num_batch_splits` is added to the config yml under the training key, the batch is split into that many sub-batches which are then processed independently, accumulating gradients. This is very similar to training with the higher batch size in the first place, and it is *fully equivalent* if https://github.com/LeelaChessZero/lczero-training/pull/29 is merged.

As a result, this allows us to exactly match A0's training scheme which used a batch size of 4096 and LR of 0.2. The config to do this should contain
```yaml
training:
    batch_size: 4096
    num_batch_splits: 8
```
in order to have a total batch size of 4096, but perform this using 8 splits of this batch of size 512 each.

As a side-effect, the number of evaluation batches increases by a factor of `num_batch_splits` over actually using a batch size of 4096 because it is using 512 size batches for those. This is fine, since evaluation results do not depend on batch size. The averaging of evaluation results already takes care of this correctly.