### PR TITLE
multigpu

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+mkdir -p tf/proto
 protoc --proto_path=libs/lczero-common --python_out=tf libs/lczero-common/proto/net.proto
 protoc --proto_path=libs/lczero-common --python_out=tf libs/lczero-common/proto/chunk.proto
 touch tf/proto/__init__.py

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -42,8 +42,7 @@ class ChunkDataSrc:
 
 class ChunkParser:
     # static batch size
-    BATCH_SIZE = 8
-    def __init__(self, chunkdatasrc, shuffle_size=1, sample=1, buffer_size=1, batch_size=256, workers=None):
+    def __init__(self, chunkdatasrc, shuffle_size=1, sample=1, batch_size=256, workers=None):
         """
         Read data and yield batches of raw tensors.
 
@@ -127,22 +126,6 @@ class ChunkParser:
             int8 result (1 byte)
         """
         self.v3_struct = struct.Struct(STRUCT_STRING)
-
-
-    @staticmethod
-    def parse_function(planes, probs, winner):
-        """
-        Convert unpacked record batches to tensors for tensorflow training
-        """
-        planes = tf.decode_raw(planes, tf.float32)
-        probs = tf.decode_raw(probs, tf.float32)
-        winner = tf.decode_raw(winner, tf.float32)
-
-        planes = tf.reshape(planes, (ChunkParser.BATCH_SIZE, 112, 8*8))
-        probs = tf.reshape(probs, (ChunkParser.BATCH_SIZE, 1858))
-        winner = tf.reshape(winner, (ChunkParser.BATCH_SIZE, 1))
-
-        return (planes, probs, winner)
 
 
     def convert_v3_to_tuple(self, content):
@@ -365,7 +348,6 @@ class ChunkParserTest(unittest.TestCase):
         """
         truth = self.generate_fake_pos()
         batch_size = 4
-        ChunkParser.BATCH_SIZE = batch_size
         records = []
         for i in range(batch_size):
             record = b''

--- a/tf/configs/128x10-swa.yaml
+++ b/tf/configs/128x10-swa.yaml
@@ -1,0 +1,74 @@
+%YAML 1.2
+---
+# network name in tensorboard and storage dir
+name: '128x10-swa4'
+
+dataset: 
+    # use this many chunks/games during training
+    num_chunks: 2650000
+    # training ratio vs test ratio
+    train_ratio: 0.90
+    # directory containing trainingdata
+    input_train: '/home/fhuizing/Downloads/chess/computer/training/train/'
+    # directory containing testdata
+    input_test: '/home/fhuizing/Downloads/chess/computer/training/test/'
+
+training:
+    # enable/disable stochastic weight averaging
+    swa: false
+    # list of gpu ids to use during training
+    gpus:
+        - 0
+        - 1
+    # cumulative batch size (positions processed per step)
+    batch_size: 2048
+    # batchsize that fits in gpu memory, must be a multiple of batch_size
+    vram_batch_size: 2048
+    # eval test set values after this many steps
+    test_steps: 1000
+    # training reports its average values after this many steps.
+    info_steps: 100
+    # terminate training after this many steps
+    total_steps: 200000
+    # create a network snapshot every n steps
+    checkpoint_steps: 10000
+    # size of the shufflebuffer in positions
+    shuffle_size: 8192
+    # nof networks to average and length of a cycle
+    swa_cycle: 10
+    # list of learning rates a1,a2 to interpolate between for swa
+    #
+    #   a(i) = (1 - t(i))*a1 + t(i)*a2
+    #   t(i) = 1/c * (mod(i - 1, c) + 1),
+    #
+    #   where i is the training iteration, a(i) is the interpolated
+    #   learningrate, c is the cycle and a1,a2 are the begin and end learning
+    #   rates such that a1 >= a2
+    lr1:
+        - 0.1
+        - 0.01
+        - 0.001
+        - 0.0001
+    lr2:
+        - 0.01
+        - 0.001
+        - 0.0001
+        - 0.00001
+    # list of boundaries, select new a1,a2 at each boundary
+    lr_boundaries:
+        - 80000
+        - 140000
+        - 180000
+    # weight of policy loss
+    policy_loss_weight: 1.0
+    # weight of value loss (should be lower with supervised learning)
+    value_loss_weight: 0.01
+    # storage directory for all networks
+    path: '/mnt/storage/home/fhuizing/chess/networks'
+
+model:
+    # number of filters per convolutional layer
+    filters: 128
+    # number of residual blocks
+    residual_blocks: 10
+...

--- a/tf/configs/example.yaml
+++ b/tf/configs/example.yaml
@@ -1,36 +1,57 @@
 %YAML 1.2
 ---
-name: 'kb1-64x6'                       # ideally no spaces
-gpu: 0                                 # gpu id to process on
+# name of the training project
+name: 'example'
 
 dataset: 
-  num_chunks: 100000                   # newest nof chunks to parse
-  train_ratio: 0.90                    # trainingset ratio
-  # For separated test and train data.
-  input_train: '/path/to/chunks/*/draw/' # supports glob
-  input_test: '/path/to/chunks/*/draw/'  # supports glob
-  # For a one-shot run with all data in one directory.
-  # input: '/path/to/chunks/*/draw/'
+    # newest nof chunks to parse
+    num_chunks: 120000
+    # trainingset ratio
+    train_ratio: 0.90
+    # For separated test and train data.
+    input_train: '/path/to/chunks/*/train/' # supports glob
+    input_test: '/path/to/chunks/*/test/' # supports glob
+    # For a one-shot run with all data in one directory.
+    # input: '/path/to/chunks/*/draw/' # supports glob
 
 training:
-    batch_size: 2048                   # training batch
-    test_steps: 2000                   # eval test set values after this many steps
-    train_avg_report_steps: 200        # training reports its average values after this many steps.
-    total_steps: 140000                # terminate after these steps
-    # checkpoint_steps: 10000          # optional frequency for checkpointing before finish
-    shuffle_size: 524288               # size of the shuffle buffer
-    lr_values:                         # list of learning rates
+    # gpu ids to train on
+    gpus:                              
+        - 0
+        - 1
+    # enable/disable stochastic weight averaging
+    swa: true
+    # training batch size
+    batch_size: 4096
+    # batchsize that fits in gpu memory, must be a multiple of batch_size
+    vram_batch_size: 512               
+    # eval test set values after this many steps
+    test_steps: 2000                   
+    # training reports its average values after this many steps.
+    info_steps: 200
+    # terminate after these steps
+    total_steps: 10000
+    # optional frequency for checkpointing before finish
+    checkpoint_steps: 2500
+    # size of the shuffle buffer
+    shuffle_size: 100000
+    # list of learning rates
+    lr_values:
+        - 0.2
         - 0.02
-        - 0.002
-        - 0.0005
-    lr_boundaries:                     # list of boundaries
-        - 100000
-        - 130000
-    policy_loss_weight: 1.0            # weight of policy loss
-    value_loss_weight: 1.0             # weight of value loss
-    path: '/path/to/store/networks'    # network storage dir
+    # list of boundaries
+    lr_boundaries:
+        - 5000
+    # weight of policy loss
+    policy_loss_weight: 1.0
+    # weight of value loss
+    value_loss_weight: 1.0
+    # network storage dir
+    path: '/path/to/store/networks'
 
 model:
-  filters: 64
-  residual_blocks: 6
+    # filters per layer
+    filters: 128
+    # residual blocks in resnet
+    residual_blocks: 10
 ...

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -16,33 +16,96 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
 
+import math
 import numpy as np
 import os
-import random
 import tensorflow as tf
 import time
+import unittest
 import bisect
-
 from net import Net
 
-def weight_variable(shape, name=None):
+
+def weight_variable(name, shape):
     """Xavier initialization"""
     stddev = np.sqrt(2.0 / (sum(shape)))
     initial = tf.truncated_normal(shape, stddev=stddev)
-    weights = tf.Variable(initial, name=name)
-    tf.add_to_collection(tf.GraphKeys.REGULARIZATION_LOSSES, weights)
+    weights = tf.get_variable(name, initializer=initial)
+    tf.add_to_collection(tf.GraphKeys.WEIGHTS, weights)
     return weights
 
 # Bias weights for layers not followed by BatchNorm
 # We do not regularlize biases, so they are not
 # added to the regularlizer collection
-def bias_variable(shape, name=None):
+def bias_variable(name, shape):
     initial = tf.constant(0.0, shape=shape)
-    return tf.Variable(initial, name=name)
+    bias = tf.get_variable(name, initializer=initial)
+    return bias
+
 
 def conv2d(x, W):
     return tf.nn.conv2d(x, W, data_format='NCHW',
                         strides=[1, 1, 1, 1], padding='SAME')
+
+# Restore session from checkpoint. It silently ignore mis-matches
+# between the checkpoint and the graph. Specifically
+# 1. values in the checkpoint for which there is no corresponding variable.
+# 2. variables in the graph for which there is no specified value in the
+#    checkpoint.
+# 3. values where the checkpoint shape differs from the variable shape.
+# (variables without a value in the checkpoint are left at their default
+# initialized value)
+def optimistic_restore(session, save_file, graph=tf.get_default_graph()):
+    reader = tf.train.NewCheckpointReader(save_file)
+    saved_shapes = reader.get_variable_to_shape_map()
+    var_names = sorted(
+        [(var.name, var.name.split(':')[0]) for var in tf.global_variables()
+         if var.name.split(':')[0] in saved_shapes])
+    restore_vars = []
+    for var_name, saved_var_name in var_names:
+        curr_var = graph.get_tensor_by_name(var_name)
+        var_shape = curr_var.get_shape().as_list()
+        if var_shape == saved_shapes[saved_var_name]:
+            restore_vars.append(curr_var)
+    opt_saver = tf.train.Saver(restore_vars)
+    opt_saver.restore(session, save_file)
+
+# Class holding statistics
+class Stats:
+    def __init__(self):
+        self.s = {}
+    def add(self, stat_dict):
+        for (k,v) in stat_dict.items():
+            if k not in self.s:
+                self.s[k] = []
+            self.s[k].append(v)
+    def n(self, name):
+        return len(self.s[name] or [])
+    def mean(self, name):
+        return np.mean(self.s[name] or [0])
+    def stddev_mean(self, name):
+        # standard deviation in the sample mean.
+        return math.sqrt(
+            np.var(self.s[name] or [0]) / max(0.0001, (len(self.s[name]) - 1)))
+    def str(self):
+        return ', '.join(
+            ["{}={:g}".format(k, np.mean(v or [0])) for k,v in self.s.items()])
+    def clear(self):
+        self.s = {}
+    def summaries(self, tags):
+        return [tf.Summary.Value(
+            tag=k, simple_value=self.mean(v)) for k,v in tags.items()]
+
+# Simple timer
+class Timer:
+    def __init__(self):
+        self.last = time.time()
+    def elapsed(self):
+        # Return time since last call to 'elapsed()'
+        t = time.time()
+        e = t - self.last
+        self.last = t
+        return e
 
 class TFProcess:
     def __init__(self, cfg):
@@ -54,109 +117,244 @@ class TFProcess:
         self.RESIDUAL_FILTERS = self.cfg['model']['filters']
         self.RESIDUAL_BLOCKS = self.cfg['model']['residual_blocks']
 
+        # Set number of GPUs for training
+        self.gpus = self.cfg['training']['gpus']
+
         # For exporting
         self.weights = []
 
-        gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.90, allow_growth=True, visible_device_list="{}".format(self.cfg['gpu']))
-        config = tf.ConfigProto(gpu_options=gpu_options)
+        # Output weight file with averaged weights
+        self.swa_enabled = self.cfg['training']['swa']
+
+        # Net sampling rate (e.g 2 == every 2nd network).
+        self.swa_c = 1
+
+        # Take an exponentially weighted moving average over this
+        # many networks. Under the SWA assumptions, this will reduce
+        # the distance to the optimal value by a factor of 1/sqrt(n)
+        self.swa_max_n = 16
+
+        # Recalculate SWA weight batchnorm means and variances
+        self.swa_recalc_bn = True
+
+        gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.9, allow_growth=True)
+        config = tf.ConfigProto(gpu_options=gpu_options, allow_soft_placement=True)
         self.session = tf.Session(config=config)
 
         self.training = tf.placeholder(tf.bool)
         self.global_step = tf.Variable(0, name='global_step', trainable=False)
+        self.lr = self.cfg['training']['lr_values'][0]
         self.learning_rate = tf.placeholder(tf.float32)
 
-    def init(self, dataset, train_iterator, test_iterator):
-        # TF variables
-        self.handle = tf.placeholder(tf.string, shape=[])
-        iterator = tf.data.Iterator.from_string_handle(
-            self.handle, dataset.output_types, dataset.output_shapes)
-        self.next_batch = iterator.get_next()
-        self.train_handle = self.session.run(train_iterator.string_handle())
-        self.test_handle = self.session.run(test_iterator.string_handle())
-        self.init_net(self.next_batch)
+    def init(self, logbase='leelalogs'):
+        self.batch_size = self.cfg['training']['vram_batch_size']
+        self.macrobatch = self.cfg['training']['batch_size'] // self.cfg['training']['vram_batch_size']
+        self.logbase = logbase
+        # Input batch placeholders
+        self.planes = tf.placeholder(tf.string, name='in_planes')
+        self.probs = tf.placeholder(tf.string, name='in_probs')
+        self.winner = tf.placeholder(tf.string, name='in_winner')
 
-    def init_net(self, next_batch):
-        self.x = next_batch[0]  # tf.placeholder(tf.float32, [None, 112, 8*8])
-        self.y_ = next_batch[1] # tf.placeholder(tf.float32, [None, 1858])
-        self.z_ = next_batch[2] # tf.placeholder(tf.float32, [None, 1])
+        # Mini-batches come as raw packed strings. Decode
+        # into tensors to feed into network.
+        planes = tf.decode_raw(self.planes, tf.float32)
+        probs = tf.decode_raw(self.probs, tf.float32)
+        winner = tf.decode_raw(self.winner, tf.float32)
+
+        planes = tf.reshape(planes, (self.batch_size, 112, 8*8))
+        probs = tf.reshape(probs, (self.batch_size, 1858))
+        winner = tf.reshape(winner, (self.batch_size, 1))
+
+        self.init_net(planes, probs, winner)
+
+    def init_net(self, planes, probs, winner):
+        gpus_num = len(self.gpus)
+        self.y_ = probs   # (tf.float32, [None, 362])
+        self.sx = tf.split(planes, gpus_num)
+        self.sy_ = tf.split(probs, gpus_num)
+        self.sz_ = tf.split(winner, gpus_num)
         self.batch_norm_count = 0
-        self.y_conv, self.z_conv = self.construct_net(self.x)
-
-        # Calculate loss on policy head
-        cross_entropy = \
-            tf.nn.softmax_cross_entropy_with_logits(labels=self.y_,
-                                                    logits=self.y_conv)
-        self.policy_loss = tf.reduce_mean(cross_entropy)
-
-        # Loss on value head
-        self.mse_loss = \
-            tf.reduce_mean(tf.squared_difference(self.z_, self.z_conv))
-
-        # Regularizer
-        regularizer = tf.contrib.layers.l2_regularizer(scale=0.0001)
-        reg_variables = tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES)
-        self.reg_term = \
-            tf.contrib.layers.apply_regularization(regularizer, reg_variables)
-
-        # For training from a (smaller) dataset of strong players, you will
-        # want to reduce the factor in front of self.mse_loss here.
-        pol_loss_w = self.cfg['training']['policy_loss_weight']
-        val_loss_w = self.cfg['training']['value_loss_weight']
-        loss = pol_loss_w * self.policy_loss + val_loss_w * self.mse_loss + self.reg_term
-
-        # Set adaptive learning rate during training
-        self.cfg['training']['lr_boundaries'].sort()
-        self.lr = self.cfg['training']['lr_values'][0]
+        self.reuse_var = None
 
         # You need to change the learning rate here if you are training
         # from a self-play training set, for example start with 0.005 instead.
-        opt_op = tf.train.MomentumOptimizer(
+        opt = tf.train.MomentumOptimizer(
             learning_rate=self.learning_rate, momentum=0.9, use_nesterov=True)
 
-        # Accumulate (possibly multiple) gradient updates to simulate larger batch sizes than can be held in GPU memory.
-        gradient_accum = [tf.Variable(tf.zeros_like(var.initialized_value()), trainable=False) for var in tf.trainable_variables()]
-        self.zero_op = [var.assign(tf.zeros_like(var)) for var in gradient_accum]
+        # Construct net here.
+        tower_grads = []
+        tower_loss = []
+        tower_policy_loss = []
+        tower_mse_loss = []
+        tower_reg_term = []
+        tower_y_conv = []
+        with tf.variable_scope(tf.get_variable_scope()):
+            for i, gpu in enumerate(self.gpus):
+                with tf.device("/gpu:%d" % gpu):
+                    with tf.name_scope("tower_%d" % i):
+                        loss, policy_loss, mse_loss, reg_term, y_conv = self.tower_loss(
+                            self.sx[i], self.sy_[i], self.sz_[i])
 
+                        # Reset batchnorm key to 0.
+                        self.reset_batchnorm_key()
+
+                        tf.get_variable_scope().reuse_variables()
+                        with tf.control_dependencies(tf.get_collection(tf.GraphKeys.UPDATE_OPS)):
+                            grads = opt.compute_gradients(loss)
+
+                        tower_grads.append(grads)
+                        tower_loss.append(loss)
+                        tower_policy_loss.append(policy_loss)
+                        tower_mse_loss.append(mse_loss)
+                        tower_reg_term.append(reg_term)
+                        tower_y_conv.append(y_conv)
+
+        # Average gradients from different GPUs
+        self.loss = tf.reduce_mean(tower_loss)
+        self.policy_loss = tf.reduce_mean(tower_policy_loss)
+        self.mse_loss = tf.reduce_mean(tower_mse_loss)
+        self.reg_term = tf.reduce_mean(tower_reg_term)
+        self.y_conv = tf.concat(tower_y_conv, axis=0)
+        self.mean_grads = self.average_gradients(tower_grads)
+
+        # Do swa after we contruct the net
+        if self.swa_enabled is True:
+            # Count of networks accumulated into SWA
+            self.swa_count = tf.Variable(0., name='swa_count', trainable=False)
+            # Count of networks to skip
+            self.swa_skip = tf.Variable(self.swa_c, name='swa_skip',
+                trainable=False)
+            # Build the SWA variables and accumulators
+            accum=[]
+            load=[]
+            n = self.swa_count
+            for w in self.weights:
+                name = w.name.split(':')[0]
+                var = tf.Variable(
+                    tf.zeros(shape=w.shape), name='swa/'+name, trainable=False)
+                accum.append(
+                    tf.assign(var, var * (n / (n + 1.)) + w * (1. / (n + 1.))))
+                load.append(tf.assign(w, var))
+            with tf.control_dependencies(accum):
+                self.swa_accum_op = tf.assign_add(n, 1.)
+            self.swa_load_op = tf.group(*load)
+
+        # Accumulate gradients
         self.update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
-        with tf.control_dependencies(self.update_ops):
-            gradients = opt_op.compute_gradients(loss)
-        self.accum_op = [accum.assign_add(gradient[0]) for accum, gradient in zip(gradient_accum, gradients)]
-        self.train_op = opt_op.apply_gradients(
-            [(accum, gradient[1]) for accum, gradient in zip(gradient_accum, gradients)], global_step=self.global_step)
+        total_grad=[]
+        grad_ops=[]
+        clear_var=[]
+        self.grad_op_real = self.mean_grads
+        for (g, v) in self.grad_op_real:
+            if g is None:
+                total_grad.append((g,v))
+            name = v.name.split(':')[0]
+            gsum = tf.get_variable(name='gsum/'+name,
+                                   shape=g.shape,
+                                   trainable=False,
+                                   initializer=tf.zeros_initializer)
+            total_grad.append((gsum, v))
+            grad_ops.append(tf.assign_add(gsum, g))
+            clear_var.append(gsum)
+        # Op to compute gradients and add to running total in 'gsum/'
+        self.grad_op = tf.group(*grad_ops)
+
+        # Op to apply accmulated gradients
+        self.train_op = opt.apply_gradients(total_grad)
+
+        zero_ops = []
+        for g in clear_var:
+            zero_ops.append(
+                tf.assign(g, tf.zeros(shape=g.shape, dtype=g.dtype)))
+        # Op to clear accumulated gradients
+        self.clear_op = tf.group(*zero_ops)
+
+        # Op to increment global step counter
+        self.step_op = tf.assign_add(self.global_step, 1)
 
         correct_prediction = \
             tf.equal(tf.argmax(self.y_conv, 1), tf.argmax(self.y_, 1))
         correct_prediction = tf.cast(correct_prediction, tf.float32)
         self.accuracy = tf.reduce_mean(correct_prediction)
 
-        self.avg_policy_loss = []
-        self.avg_mse_loss = []
-        self.avg_reg_term = []
-        self.time_start = None
-        self.last_steps = None
-
         # Summary part
         self.test_writer = tf.summary.FileWriter(
-            os.path.join(os.getcwd(), "leelalogs/{}-test".format(self.cfg['name'])), self.session.graph)
+            os.path.join(self.root_dir,
+                         self.logbase + "/" + self.cfg['name'] + "-test"), self.session.graph)
         self.train_writer = tf.summary.FileWriter(
-            os.path.join(os.getcwd(), "leelalogs/{}-train".format(self.cfg['name'])), self.session.graph)
-        self.histograms = [tf.summary.histogram(weight.name, weight) for weight in self.weights]
+            os.path.join(self.root_dir,
+                         self.logbase + "/" + self.cfg['name'] + "-train"), self.session.graph)
 
-        self.init = tf.global_variables_initializer()
+        # Build checkpoint saver
         self.saver = tf.train.Saver()
 
-        self.session.run(self.init)
+        # Initialize all variables
+        self.session.run(tf.global_variables_initializer())
+
+    def average_gradients(self, tower_grads):
+        # Average gradients from different GPUs
+        average_grads = []
+        for grad_and_vars in zip(*tower_grads):
+            grads = []
+            for g, _ in grad_and_vars:
+                expanded_g = tf.expand_dims(g, dim=0)
+                grads.append(expanded_g)
+
+            grad = tf.concat(grads, axis=0)
+            grad = tf.reduce_mean(grad, reduction_indices=0)
+
+            v = grad_and_vars[0][1]
+            grad_and_var = (grad, v)
+            average_grads.append(grad_and_var)
+        return average_grads
+
+    def tower_loss(self, x, y_, z_):
+        y_conv, z_conv = self.construct_net(x)
+        # Calculate loss on policy head
+        cross_entropy = \
+            tf.nn.softmax_cross_entropy_with_logits(labels=y_,
+                                                    logits=y_conv)
+        policy_loss = tf.reduce_mean(cross_entropy)
+
+        # Loss on value head
+        mse_loss = \
+            tf.reduce_mean(tf.squared_difference(z_, z_conv))
+
+        # Regularizer
+        regularizer = tf.contrib.layers.l2_regularizer(scale=0.0001)
+        reg_variables = tf.get_collection(tf.GraphKeys.WEIGHTS)
+        reg_term = \
+            tf.contrib.layers.apply_regularization(regularizer, reg_variables)
+
+        # For training from a (smaller) dataset of strong players, you will
+        # want to reduce the factor in front of self.mse_loss here.
+        pol_loss_w = self.cfg['training']['policy_loss_weight']
+        val_loss_w = self.cfg['training']['value_loss_weight']
+        loss = pol_loss_w * policy_loss + val_loss_w * mse_loss + reg_term
+
+        return loss, policy_loss, mse_loss, reg_term, y_conv
+
+    def assign(self, var, values):
+        try:
+            self.session.run(tf.assign(var, values))
+        except:
+            print("Failed to assign {}: var shape {}, values shape {}".format(
+                var.name, var.shape, values.shape))
+            raise
 
     def replace_weights(self, new_weights):
         for e, weights in enumerate(self.weights):
+            if isinstance(weights, str):
+                weights = tf.get_default_graph().get_tensor_by_name(weights)
             if weights.name.endswith('/batch_normalization/beta:0'):
-                # Batch norm beta is written as bias before the batch normalization
-                # in the weight file for backwards compatibility reasons.
+                # Batch norm beta is written as bias before the batch
+                # normalization in the weight file for backwards
+                # compatibility reasons.
                 bias = tf.constant(new_weights[e], shape=weights.shape)
                 # Weight file order: bias, means, variances
                 var = tf.constant(new_weights[e + 2], shape=weights.shape)
                 new_beta = tf.divide(bias, tf.sqrt(var + tf.constant(1e-5)))
-                self.session.run(tf.assign(weights, new_beta))
+                self.assign(weights, new_beta)
             elif weights.shape.ndims == 4:
                 # Rescale rule50 related weights as clients do not normalize the input.
                 if e == 0:
@@ -166,7 +364,6 @@ class TFProcess:
                     for i in range(len(new_weights[e])):
                         if (i%(num_inputs*9))//9 == rule50_input:
                             new_weights[e][i] = new_weights[e][i]*99
-
                 # Convolution weights need a transpose
                 #
                 # TF (kYXInputOutput)
@@ -177,7 +374,7 @@ class TFProcess:
                 s = weights.shape.as_list()
                 shape = [s[i] for i in [3, 2, 0, 1]]
                 new_weight = tf.constant(new_weights[e], shape=shape)
-                self.session.run(weights.assign(tf.transpose(new_weight, [2, 3, 1, 0])))
+                self.assign(weights, tf.transpose(new_weight, [2, 3, 1, 0]))
             elif weights.shape.ndims == 2:
                 # Fully connected layers are [in, out] in TF
                 #
@@ -186,151 +383,95 @@ class TFProcess:
                 s = weights.shape.as_list()
                 shape = [s[i] for i in [1, 0]]
                 new_weight = tf.constant(new_weights[e], shape=shape)
-                self.session.run(weights.assign(tf.transpose(new_weight, [1, 0])))
+                self.assign(weights, tf.transpose(new_weight, [1, 0]))
             else:
                 # Biases, batchnorm etc
                 new_weight = tf.constant(new_weights[e], shape=weights.shape)
-                self.session.run(tf.assign(weights, new_weight))
-        #This should result in identical file to the starting one
-        #self.save_leelaz_weights('restored.txt')
+                self.assign(weights, new_weight)
 
-    def restore(self, file):
-        print("Restoring from {0}".format(file))
-        self.saver.restore(self.session, file)
+    def restore(self, filename):
+        print("Restoring from {0}".format(filename))
+        optimistic_restore(self.session, filename)
 
-    def process_loop(self, batch_size, test_batches, batch_splits=1):
-        # Get the initial steps value in case this is a resume from a step count
-        # which is not a multiple of total_steps.
-        steps = tf.train.global_step(self.session, self.global_step)
+    def measure_loss(self, batch, training=False):
+        # Measure loss over one batch. If training is true, also
+        # accumulate the gradient and increment the global step.
+        ops = [self.policy_loss, self.mse_loss, self.reg_term, self.accuracy]
+        if training:
+            ops += [self.grad_op, self.step_op],
+        r = self.session.run(ops, feed_dict={self.training: training,
+                           self.learning_rate: self.lr,
+                           self.planes: batch[0],
+                           self.probs: batch[1],
+                           self.winner: batch[2]})
+        # Google's paper scales mse by 1/4 to a [0,1] range, so we do the same here
+        return {'policy': r[0], 'mse': r[1]/4., 'reg': r[2],
+                'accuracy': r[3], 'total': r[0]+r[1]+r[2] }
+
+    def process(self, train_data, test_data, num_evals):
         total_steps = self.cfg['training']['total_steps']
-        for _ in range(steps % total_steps, total_steps):
-            self.process(batch_size, test_batches, batch_splits=batch_splits)
-
-    def process(self, batch_size, test_batches, batch_splits=1):
-        if not self.time_start:
-            self.time_start = time.time()
-
-        # Get the initial steps value before we do a training step.
-        steps = tf.train.global_step(self.session, self.global_step)
-        if not self.last_steps:
-            self.last_steps = steps
-
-        # Run test before first step to see delta since end of last run.
-        if steps % self.cfg['training']['total_steps'] == 0:
-            # Steps is given as one higher than current in order to avoid it
-            # being equal to the value the end of a run is stored against.
-            self.calculate_test_summaries(test_batches, steps + 1)
-
-        # Make sure that ghost batch norm can be applied
-        if batch_size % 64 != 0:
-            # Adjust required batch size for batch splitting.
-            required_factor = 64 * self.cfg['training'].get('num_batch_splits', 1)
-            raise ValueError('batch_size must be a multiple of {}'.format(required_factor))
-
-        # Run training for this batch
-        self.session.run(self.zero_op)
-        for _ in range(batch_splits):
-            policy_loss, mse_loss, reg_term, _, _ = self.session.run(
-                [self.policy_loss, self.mse_loss, self.reg_term, self.accum_op,
-                    self.next_batch],
-                feed_dict={self.training: True, self.handle: self.train_handle})
-            # Keep running averages
-            # Google's paper scales MSE by 1/4 to a [0, 1] range, so do the same to
-            # get comparable values.
-            mse_loss /= 4.0
-            self.avg_policy_loss.append(policy_loss)
-            self.avg_mse_loss.append(mse_loss)
-            self.avg_reg_term.append(reg_term)
-        # Gradients of batch splits are summed, not averaged like usual, so need to scale lr accordingly to correct for this.
-        corrected_lr = self.lr / batch_splits
-        self.session.run(self.train_op,
-            feed_dict={self.learning_rate: corrected_lr, self.training: True, self.handle: self.train_handle})
-
-        # Update steps since training should have incremented it.
-        steps = tf.train.global_step(self.session, self.global_step)
-
-        # Determine learning rate
+        info_steps = self.cfg['training']['info_steps']
+        test_steps = self.cfg['training']['test_steps']
         lr_values = self.cfg['training']['lr_values']
         lr_boundaries = self.cfg['training']['lr_boundaries']
-        steps_total = (steps-1) % self.cfg['training']['total_steps']
-        self.lr = lr_values[bisect.bisect_right(lr_boundaries, steps_total)]
+        checkpoint_steps = self.cfg['training'].get('checkpoint_steps', total_steps)
+        stats = Stats()
+        timer = Timer()
+        for i in range(total_steps):
+            batch = next(train_data)
+            stats.add({'lr': self.lr})
+            # Measure losses and compute gradients for this batch.
+            losses = self.measure_loss(batch, training=True)
+            # fetch the current global step.
+            steps = tf.train.global_step(self.session, self.global_step)
+            mod_steps = steps % total_steps
+            self.lr = lr_values[bisect.bisect_right(lr_boundaries, mod_steps)]
+            stats.add(losses)
+            if steps % self.macrobatch == (self.macrobatch-1):
+                # Apply the accumulated gradients to the weights.
+                self.session.run([self.train_op], feed_dict={self.learning_rate: self.lr})
+                # Clear the accumulated gradient.
+                self.session.run([self.clear_op], feed_dict={self.learning_rate: self.lr})
 
-        if steps % self.cfg['training']['train_avg_report_steps'] == 0 or steps % self.cfg['training']['total_steps'] == 0:
-            pol_loss_w = self.cfg['training']['policy_loss_weight']
-            val_loss_w = self.cfg['training']['value_loss_weight']
-            time_end = time.time()
-            speed = 0
-            if self.time_start:
-                elapsed = time_end - self.time_start
-                steps_elapsed = steps - self.last_steps
-                speed = batch_size * (steps_elapsed / elapsed)
-            avg_policy_loss = np.mean(self.avg_policy_loss or [0])
-            avg_mse_loss = np.mean(self.avg_mse_loss or [0])
-            avg_reg_term = np.mean(self.avg_reg_term or [0])
-            print("step {}, lr={:g} policy={:g} mse={:g} reg={:g} total={:g} ({:g} pos/s)".format(
-                steps, self.lr, avg_policy_loss, avg_mse_loss, avg_reg_term,
-                # Scale mse_loss back to the original to reflect the actual
-                # value being optimized.
-                # If you changed the factor in the loss formula above, you need
-                # to change it here as well for correct outputs.
-                pol_loss_w * avg_policy_loss + val_loss_w * 4.0 * avg_mse_loss + avg_reg_term,
-                speed))
-            train_summaries = tf.Summary(value=[
-                tf.Summary.Value(tag="Policy Loss", simple_value=avg_policy_loss),
-                tf.Summary.Value(tag="Reg term", simple_value=avg_reg_term),
-                tf.Summary.Value(tag="LR", simple_value=self.lr),
-                tf.Summary.Value(tag="MSE Loss", simple_value=avg_mse_loss)])
-            self.train_writer.add_summary(train_summaries, steps)
-            self.time_start = time_end
-            self.last_steps = steps
-            self.avg_policy_loss, self.avg_mse_loss, self.avg_reg_term = [], [], []
+            if steps % info_steps == 0:
+                speed = info_steps * self.batch_size / timer.elapsed()
+                print("step {}, policy={:g} mse={:g} reg={:g} total={:g} ({:g} pos/s)".format(
+                    steps, stats.mean('policy'), stats.mean('mse'), stats.mean('reg'),
+                    stats.mean('total'), speed))
+                summaries = stats.summaries({'Policy Loss': 'policy',
+                    'MSE Loss': 'mse', 'LR': 'lr', 'Reg Term': 'reg'})
+                self.train_writer.add_summary(
+                    tf.Summary(value=summaries), steps)
+                stats.clear()
 
-        # Calculate test values every 'test_steps', but also ensure there is
-        # one at the final step so the delta to the first step can be calculted.
-        if steps % self.cfg['training']['test_steps'] == 0 or steps % self.cfg['training']['total_steps'] == 0:
-            self.calculate_test_summaries(test_batches, steps)
+            if steps % test_steps == 0:
+                test_stats = Stats()
+                for _ in range(num_evals):
+                    test_batch = next(test_data)
+                    losses = self.measure_loss(test_batch, training=False)
+                    test_stats.add(losses)
+                summaries = test_stats.summaries({'Policy Loss': 'policy',
+                                                  'MSE Loss': 'mse',
+                                                  'Accuracy': 'accuracy'})
+                self.test_writer.add_summary(tf.Summary(value=summaries), steps)
+                print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\
+                    format(steps, test_stats.mean('policy'),
+                        test_stats.mean('accuracy')*100.0,
+                        test_stats.mean('mse')))
 
-        # Save session and weights at end, and also optionally every 'checkpoint_steps'.
-        if steps % self.cfg['training']['total_steps'] == 0 or (
-                'checkpoint_steps' in self.cfg['training'] and steps % self.cfg['training']['checkpoint_steps'] == 0):
-            path = os.path.join(self.root_dir, self.cfg['name'])
-            save_path = self.saver.save(self.session, path, global_step=steps)
-            print("Model saved in file: {}".format(save_path))
-            leela_path = path + "-" + str(steps)
-            self.net.pb.training_params.training_steps = steps
-            self.save_leelaz_weights(leela_path) 
-            print("Weights saved in file: {}".format(leela_path))
+            if steps % checkpoint_steps == 0:
+                path = os.path.join(self.root_dir, self.cfg['name'])
+                leela_path = path + "-" + str(steps)
+                self.net.pb.training_params.training_steps = steps
+                self.save_leelaz_weights(leela_path)
+                print("Weights saved in file: {}".format(leela_path))
 
-    def calculate_test_summaries(self, test_batches, steps):
-        sum_accuracy = 0
-        sum_mse = 0
-        sum_policy = 0
-        for _ in range(0, test_batches):
-            test_policy, test_accuracy, test_mse, _ = self.session.run(
-                [self.policy_loss, self.accuracy, self.mse_loss,
-                 self.next_batch],
-                feed_dict={self.training: False,
-                           self.handle: self.test_handle})
-            sum_accuracy += test_accuracy
-            sum_mse += test_mse
-            sum_policy += test_policy
-        sum_accuracy /= test_batches
-        sum_accuracy *= 100
-        sum_policy /= test_batches
-        # Additionally rescale to [0, 1] so divide by 4
-        sum_mse /= (4.0 * test_batches)
-        self.net.pb.training_params.learning_rate = self.lr
-        self.net.pb.training_params.mse_loss = sum_mse
-        self.net.pb.training_params.policy_loss = sum_policy
-        self.net.pb.training_params.accuracy = sum_accuracy
-        test_summaries = tf.Summary(value=[
-            tf.Summary.Value(tag="Accuracy", simple_value=sum_accuracy),
-            tf.Summary.Value(tag="Policy Loss", simple_value=sum_policy),
-            tf.Summary.Value(tag="MSE Loss", simple_value=sum_mse)]).SerializeToString()
-        test_summaries = tf.summary.merge([test_summaries] + self.histograms).eval(session=self.session)
-        self.test_writer.add_summary(test_summaries, steps)
-        print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\
-            format(steps, sum_policy, sum_accuracy, sum_mse))
+                if self.swa_enabled:
+                    self.save_swa_network(steps, path, leela_path, train_data)
+
+                save_path = self.saver.save(self.session, path,
+                                            global_step=steps)
+                print("Model saved in file: {}".format(save_path))
 
     def save_leelaz_weights(self, filename):
         all_weights = []
@@ -385,98 +526,69 @@ class TFProcess:
         self.batch_norm_count += 1
         return result
 
-    def conv_block(self, inputs, filter_size, input_channels, output_channels):
+    def reset_batchnorm_key(self):
+        self.batch_norm_count = 0
+        self.reuse_var = True
+
+    def add_weights(self, variable):
+        if self.reuse_var is None:
+            self.weights.append(variable)
+
+    def batch_norm(self, net):
         # The weights are internal to the batchnorm layer, so apply
         # a unique scope that we can store, and use to look them back up
         # later on.
-        weight_key = self.get_batchnorm_key()
-        conv_key = weight_key + "/conv_weight"
-        W_conv = weight_variable([filter_size, filter_size,
-                                  input_channels, output_channels], name=conv_key)
-
-        with tf.variable_scope(weight_key):
-            h_bn = \
-                tf.layers.batch_normalization(
-                    conv2d(inputs, W_conv),
+        scope = self.get_batchnorm_key()
+        with tf.variable_scope(scope):
+            net = tf.layers.batch_normalization(
+                    net,
                     epsilon=1e-5, axis=1, fused=True,
                     center=True, scale=False,
-                    virtual_batch_size=64,
-                    training=self.training)
-        h_conv = tf.nn.relu(h_bn)
+                    training=self.training,
+                    reuse=self.reuse_var)
 
-        beta_key = weight_key + "/batch_normalization/beta:0"
-        mean_key = weight_key + "/batch_normalization/moving_mean:0"
-        var_key = weight_key + "/batch_normalization/moving_variance:0"
+        for v in ['beta', 'moving_mean', 'moving_variance' ]:
+            name = scope + '/batch_normalization/' + v + ':0'
+            var = tf.get_default_graph().get_tensor_by_name(name)
+            self.add_weights(var)
 
-        beta = tf.get_default_graph().get_tensor_by_name(beta_key)
-        mean = tf.get_default_graph().get_tensor_by_name(mean_key)
-        var = tf.get_default_graph().get_tensor_by_name(var_key)
+        return net
 
-        self.weights.append(W_conv)
-        self.weights.append(beta)
-        self.weights.append(mean)
-        self.weights.append(var)
+    def conv_block(self, inputs, filter_size, input_channels, output_channels, name):
+        W_conv = weight_variable(
+            name,
+            [filter_size, filter_size, input_channels, output_channels])
 
-        return h_conv
+        self.add_weights(W_conv)
 
-    def residual_block(self, inputs, channels):
-        # First convnet
-        orig = tf.identity(inputs)
-        weight_key_1 = self.get_batchnorm_key()
-        conv_key_1 = weight_key_1 + "/conv_weight"
-        W_conv_1 = weight_variable([3, 3, channels, channels], name=conv_key_1)
+        net = inputs
+        net = conv2d(net, W_conv)
+        net = self.batch_norm(net)
+        net = tf.nn.relu(net)
+        return net
 
-        # Second convnet
-        weight_key_2 = self.get_batchnorm_key()
-        conv_key_2 = weight_key_2 + "/conv_weight"
-        W_conv_2 = weight_variable([3, 3, channels, channels], name=conv_key_2)
+    def residual_block(self, inputs, channels, name):
+        net = inputs
+        orig = tf.identity(net)
 
-        with tf.variable_scope(weight_key_1):
-            h_bn1 = \
-                tf.layers.batch_normalization(
-                    conv2d(inputs, W_conv_1),
-                    epsilon=1e-5, axis=1, fused=True,
-                    center=True, scale=False,
-                    virtual_batch_size=64,
-                    training=self.training)
-        h_out_1 = tf.nn.relu(h_bn1)
-        with tf.variable_scope(weight_key_2):
-            h_bn2 = \
-                tf.layers.batch_normalization(
-                    conv2d(h_out_1, W_conv_2),
-                    epsilon=1e-5, axis=1, fused=True,
-                    center=True, scale=False,
-                    virtual_batch_size=64,
-                    training=self.training)
-        h_out_2 = tf.nn.relu(tf.add(h_bn2, orig))
+        # First convnet weights
+        W_conv_1 = weight_variable(name + "_conv_1", [3, 3, channels, channels])
+        self.add_weights(W_conv_1)
 
-        beta_key_1 = weight_key_1 + "/batch_normalization/beta:0"
-        mean_key_1 = weight_key_1 + "/batch_normalization/moving_mean:0"
-        var_key_1 = weight_key_1 + "/batch_normalization/moving_variance:0"
+        net = conv2d(net, W_conv_1)
+        net = self.batch_norm(net)
+        net = tf.nn.relu(net)
 
-        beta_1 = tf.get_default_graph().get_tensor_by_name(beta_key_1)
-        mean_1 = tf.get_default_graph().get_tensor_by_name(mean_key_1)
-        var_1 = tf.get_default_graph().get_tensor_by_name(var_key_1)
+        # Second convnet weights
+        W_conv_2 = weight_variable(name + "_conv_2", [3, 3, channels, channels])
+        self.add_weights(W_conv_2)
 
-        beta_key_2 = weight_key_2 + "/batch_normalization/beta:0"
-        mean_key_2 = weight_key_2 + "/batch_normalization/moving_mean:0"
-        var_key_2 = weight_key_2 + "/batch_normalization/moving_variance:0"
+        net = conv2d(net, W_conv_2)
+        net = self.batch_norm(net)
+        net = tf.add(net, orig)
+        net = tf.nn.relu(net)
 
-        beta_2 = tf.get_default_graph().get_tensor_by_name(beta_key_2)
-        mean_2 = tf.get_default_graph().get_tensor_by_name(mean_key_2)
-        var_2 = tf.get_default_graph().get_tensor_by_name(var_key_2)
-
-        self.weights.append(W_conv_1)
-        self.weights.append(beta_1)
-        self.weights.append(mean_1)
-        self.weights.append(var_1)
-
-        self.weights.append(W_conv_2)
-        self.weights.append(beta_2)
-        self.weights.append(mean_2)
-        self.weights.append(var_2)
-
-        return h_out_2
+        return net
 
     def construct_net(self, planes):
         # NCHW format
@@ -486,36 +598,132 @@ class TFProcess:
         # Input convolution
         flow = self.conv_block(x_planes, filter_size=3,
                                input_channels=112,
-                               output_channels=self.RESIDUAL_FILTERS)
+                               output_channels=self.RESIDUAL_FILTERS,
+                               name="first_conv")
         # Residual tower
-        for _ in range(0, self.RESIDUAL_BLOCKS):
-            flow = self.residual_block(flow, self.RESIDUAL_FILTERS)
+        for i in range(0, self.RESIDUAL_BLOCKS):
+            block_name = "res_" + str(i)
+            flow = self.residual_block(flow, self.RESIDUAL_FILTERS,
+                                       name=block_name)
 
         # Policy head
         conv_pol = self.conv_block(flow, filter_size=1,
                                    input_channels=self.RESIDUAL_FILTERS,
-                                   output_channels=32)
-        h_conv_pol_flat = tf.reshape(conv_pol, [-1, 32*8*8])
-        W_fc1 = weight_variable([32*8*8, 1858], name='fc1/weight')
-        b_fc1 = bias_variable([1858], name='fc1/bias')
-        self.weights.append(W_fc1)
-        self.weights.append(b_fc1)
-        h_fc1 = tf.add(tf.matmul(h_conv_pol_flat, W_fc1), b_fc1, name='policy_head')
+                                   output_channels=32,
+                                   name="policy_head")
+        h_conv_pol_flat = tf.reshape(conv_pol, [-1, 32 * 8 * 8])
+        W_fc1 = weight_variable("w_fc_1", [32 * 8 * 8, 1858])
+        b_fc1 = bias_variable("b_fc_1", [1858])
+        self.add_weights(W_fc1)
+        self.add_weights(b_fc1)
+        h_fc1 = tf.add(tf.matmul(h_conv_pol_flat, W_fc1), b_fc1)
 
         # Value head
         conv_val = self.conv_block(flow, filter_size=1,
                                    input_channels=self.RESIDUAL_FILTERS,
-                                   output_channels=32)
-        h_conv_val_flat = tf.reshape(conv_val, [-1, 32*8*8])
-        W_fc2 = weight_variable([32 * 8 * 8, 128], name='fc2/weight')
-        b_fc2 = bias_variable([128], name='fc2/bias')
-        self.weights.append(W_fc2)
-        self.weights.append(b_fc2)
+                                   output_channels=32,
+                                   name="value_head")
+        h_conv_val_flat = tf.reshape(conv_val, [-1, 32 * 8 * 8])
+        W_fc2 = weight_variable("w_fc_2", [32 * 8 * 8, 256])
+        b_fc2 = bias_variable("b_fc_2", [256])
+        self.add_weights(W_fc2)
+        self.add_weights(b_fc2)
         h_fc2 = tf.nn.relu(tf.add(tf.matmul(h_conv_val_flat, W_fc2), b_fc2))
-        W_fc3 = weight_variable([128, 1], name='fc3/weight')
-        b_fc3 = bias_variable([1], name='fc3/bias')
-        self.weights.append(W_fc3)
-        self.weights.append(b_fc3)
-        h_fc3 = tf.nn.tanh(tf.add(tf.matmul(h_fc2, W_fc3), b_fc3), name='value_head')
+        W_fc3 = weight_variable("w_fc_3", [256, 1])
+        b_fc3 = bias_variable("b_fc_3", [1])
+        self.add_weights(W_fc3)
+        self.add_weights(b_fc3)
+        h_fc3 = tf.nn.tanh(tf.add(tf.matmul(h_fc2, W_fc3), b_fc3))
 
         return h_fc1, h_fc3
+
+    def snap_save(self):
+        # Save a snapshot of all the variables in the current graph.
+        if not hasattr(self, 'save_op'):
+            save_ops = []
+            rest_ops = []
+            for var in self.weights:
+                if isinstance(var, str):
+                    var = tf.get_default_graph().get_tensor_by_name(var)
+                name = var.name.split(':')[0]
+                v = tf.Variable(var, name='save/'+name, trainable=False)
+                save_ops.append(tf.assign(v, var))
+                rest_ops.append(tf.assign(var, v))
+            self.save_op = tf.group(*save_ops)
+            self.restore_op = tf.group(*rest_ops)
+        self.session.run(self.save_op)
+
+    def snap_restore(self):
+        # Restore variables in the current graph from the snapshot.
+        self.session.run(self.restore_op)
+
+    def save_swa_network(self, steps, path, leela_path, data):
+        # Sample 1 in self.swa_c of the networks. Compute in this way so
+        # that it's safe to change the value of self.swa_c
+        rem = self.session.run(tf.assign_add(self.swa_skip, -1))
+        if rem > 0:
+            return
+        self.swa_skip.load(self.swa_c, self.session)
+
+        # Add the current weight vars to the running average.
+        num = self.session.run(self.swa_accum_op)
+
+        if self.swa_max_n != None:
+            num = min(num, self.swa_max_n)
+            self.swa_count.load(float(num), self.session)
+
+        swa_path = path + "-swa-" + str(int(num)) + "-" + str(steps)
+
+        # save the current network.
+        self.snap_save()
+        # Copy the swa weights into the current network.
+        self.session.run(self.swa_load_op)
+        if self.swa_recalc_bn:
+            print("Refining SWA batch normalization")
+            for _ in range(200):
+                batch = next(data)
+                self.session.run(
+                    [self.loss, self.update_ops],
+                    feed_dict={self.training: True,
+                               self.learning_rate: self.lr,
+                               self.planes: batch[0], self.probs: batch[1],
+                               self.winner: batch[2]})
+
+        self.save_leelaz_weights(swa_path)
+        # restore the saved network.
+        self.snap_restore()
+
+        print("Wrote averaged network to {}".format(swa_path))
+
+# Unit tests for TFProcess.
+def gen_block(size, f_in, f_out):
+    return [ [1.1] * size * size * f_in * f_out, # conv
+             [-.1] * f_out,  # bias weights
+             [-.2] * f_out,  # batch norm mean
+             [-.3] * f_out ] # batch norm var
+
+class TFProcessTest(unittest.TestCase):
+    def test_can_replace_weights(self):
+        tfprocess = TFProcess()
+        tfprocess.init(batch_size=1)
+        # use known data to test replace_weights() works.
+        data = gen_block(3, 18, tfprocess.RESIDUAL_FILTERS) # input conv
+        for _ in range(tfprocess.RESIDUAL_BLOCKS):
+            data.extend(gen_block(3,
+                tfprocess.RESIDUAL_FILTERS, tfprocess.RESIDUAL_FILTERS))
+            data.extend(gen_block(3,
+                tfprocess.RESIDUAL_FILTERS, tfprocess.RESIDUAL_FILTERS))
+        # policy
+        data.extend(gen_block(1, tfprocess.RESIDUAL_FILTERS, 2))
+        data.append([0.4] * 2*19*19 * (19*19+1))
+        data.append([0.5] * (19*19+1))
+        # value
+        data.extend(gen_block(1, tfprocess.RESIDUAL_FILTERS, 1))
+        data.append([0.6] * 19*19 * 256)
+        data.append([0.7] * 256)
+        data.append([0.8] * 256)
+        data.append([0.9] * 1)
+        tfprocess.replace_weights(data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tf/train.py
+++ b/tf/train.py
@@ -120,7 +120,7 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-    num_evals = num_test*10 // ram_batch_size
+    num_evals = num_test // ram_batch_size
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process(train_parser.parse(), test_parser.parse(), num_evals)


### PR DESCRIPTION
This is quite an extensive rewrite of tfprocess.py. I ported the latest code from [leela-zero](https://github.com/gcp/leela-zero) to enable multigpu. We also get stochastic weight averaging for free as they implemented that also (very nice work).

For testing I trained both with the old code and new code. The new multigpu code seems to run 2x faster for 256x20 on my 2x 1080Ti. But going to 128x10 shows regression compared to the single gpu. Presumably there's too much cpu overhead.