### PR TITLE
Update TF requirement to 1.10

### DIFF
--- a/tf/requirements.txt
+++ b/tf/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.13.3
-tensorflow==1.4.0
+tensorflow==1.10.0
 tensorflow-tensorboard==0.4.0rc2


### PR DESCRIPTION
Training crashes with 1.4 because it doesn't support `virtual_batch_size`