### PR TITLE
Fix scale of weight initialization

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -34,7 +34,9 @@ def weight_variable(shape, name=None):
     else:
         fan_in = shape[0]
         fan_out = shape[1]
-    stddev = np.sqrt(2.0 / (fan_in + fan_out))
+    # truncated normal has lower stddev than a regular normal distribution, so need to correct for that 
+    trunc_correction = math.sqrt(1.3)
+    stddev = trunc_correction * np.sqrt(2.0 / (fan_in + fan_out))
     initial = tf.truncated_normal(shape, stddev=stddev)
     weights = tf.Variable(initial, name=name)
     tf.add_to_collection(tf.GraphKeys.REGULARIZATION_LOSSES, weights)

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -27,7 +27,14 @@ from net import Net
 
 def weight_variable(shape, name=None):
     """Xavier initialization"""
-    stddev = np.sqrt(2.0 / (sum(shape)))
+    if len(shape) == 4:
+        receptive_field = shape[0] * shape[1]
+        fan_in = shape[2] * receptive_field
+        fan_out = shape[3] * receptive_field
+    else:
+        fan_in = shape[0]
+        fan_out = shape[1]
+    stddev = np.sqrt(2.0 / (fan_in + fan_out))
     initial = tf.truncated_normal(shape, stddev=stddev)
     weights = tf.Variable(initial, name=name)
     tf.add_to_collection(tf.GraphKeys.REGULARIZATION_LOSSES, weights)

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -35,7 +35,7 @@ def weight_variable(shape, name=None):
         fan_in = shape[0]
         fan_out = shape[1]
     # truncated normal has lower stddev than a regular normal distribution, so need to correct for that 
-    trunc_correction = math.sqrt(1.3)
+    trunc_correction = np.sqrt(1.3)
     stddev = trunc_correction * np.sqrt(2.0 / (fan_in + fan_out))
     initial = tf.truncated_normal(shape, stddev=stddev)
     weights = tf.Variable(initial, name=name)


### PR DESCRIPTION
The previous implementation of Xavier init is completely wrong for conv layers, initialising values too large. This is likely the cause for the long time that a new net needs to be trained before the mse loss drops, and as sergiovieri points out, during this period the value head output is always 1. Also, notice how the moving variances for the first BN in every residual block in the current Tensorboard are close to 1 at the start of the net as they should be, but gradually move to over 100 as you get deeper into the network. This is a sign that the scale of the activations in the identity path in the ResNet is growing significantly throughout residual blocks.

This PR changes the init to be the correct Xavier initialisation for a Gaussian (as opposed to the original uniform distribution in Xavier's paper, but this doesn't really matter). The implementation here matches the official TF implementation and the official PyTorch implementation:

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/layers/python/layers/initializers.py#L62
https://github.com/pytorch/pytorch/blob/master/torch/nn/init.py#L225

For the conv layers, the stdev of the [3, 3, 256, 256] tensor is:

> sqrt(2 / (3 + 3 + 256 + 256)) = 0.062

when it should be

> sqrt(2 / (3 * 3 * 256 + 3 * 3 * 256)) = 0.021

in order to correctly maintain the scale of the activations and gradients throughout the network.