### PR TITLE
Add support for warmup steps.

### DIFF
--- a/tf/configs/example.yaml
+++ b/tf/configs/example.yaml
@@ -17,6 +17,7 @@ training:
     test_steps: 2000                   # eval test set values after this many steps
     train_avg_report_steps: 200        # training reports its average values after this many steps.
     total_steps: 140000                # terminate after these steps
+    warmup_steps: 250                  # if global step is less than this, scale the current LR by ratio of global step to this value
     # checkpoint_steps: 10000          # optional frequency for checkpointing before finish
     shuffle_size: 524288               # size of the shuffle buffer
     lr_values:                         # list of learning rates

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -115,6 +115,7 @@ class TFProcess:
 
         # Set adaptive learning rate during training
         self.cfg['training']['lr_boundaries'].sort()
+        self.warmup_steps = self.cfg['training'].get('warmup_steps', 0)
         self.lr = self.cfg['training']['lr_values'][0]
 
         # You need to change the learning rate here if you are training
@@ -236,6 +237,14 @@ class TFProcess:
             required_factor = 64 * self.cfg['training'].get('num_batch_splits', 1)
             raise ValueError('batch_size must be a multiple of {}'.format(required_factor))
 
+        # Determine learning rate
+        lr_values = self.cfg['training']['lr_values']
+        lr_boundaries = self.cfg['training']['lr_boundaries']
+        steps_total = steps % self.cfg['training']['total_steps']
+        self.lr = lr_values[bisect.bisect_right(lr_boundaries, steps_total)]
+        if self.warmup_steps > 0 and steps < self.warmup_steps
+             self.lr = self.lr * steps / self.warmup_steps
+
         # Run training for this batch
         self.session.run(self.zero_op)
         for _ in range(batch_splits):
@@ -257,12 +266,6 @@ class TFProcess:
 
         # Update steps since training should have incremented it.
         steps = tf.train.global_step(self.session, self.global_step)
-
-        # Determine learning rate
-        lr_values = self.cfg['training']['lr_values']
-        lr_boundaries = self.cfg['training']['lr_boundaries']
-        steps_total = (steps-1) % self.cfg['training']['total_steps']
-        self.lr = lr_values[bisect.bisect_right(lr_boundaries, steps_total)]
 
         if steps % self.cfg['training']['train_avg_report_steps'] == 0 or steps % self.cfg['training']['total_steps'] == 0:
             pol_loss_w = self.cfg['training']['policy_loss_weight']


### PR DESCRIPTION
As a side effect of moving LR calculation before the training in each process call this also means that reported LR is actually the LR just used.  It also moves transitions between LR values one step earlier - but I think that is also fine.

I haven't tested this exact code, but I did test this strategy (with a value of approximately 130) and it, in combination with the recent changes to net initial weights, means we can successfully init a net without the MSE ever saturating.  So rather than up to 20k steps before we start reinforcement waiting for it to solve vanishing gradients, we are just teaching it the basics from the start pretty much.  I would suggest 1k steps would be plenty before releasing to reinforcement learning.