### PR TITLE
Log update ratio of weights

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -362,8 +362,8 @@ class TFProcess:
         ratios = [(tensor.name, d / w) for d, w, tensor in zip(delta_norms, weight_norms, self.weights) if not 'moving' in tensor.name]
         all_summaries = [
             tf.Summary.Value(tag='update_ratios/' +
-                             tensor.name, simple_value=ratio)
-            for tensor, ratio in ratios]
+                             name, simple_value=ratio)
+            for name, ratio in ratios]
         ratios = np.log10([r for (_, r) in ratios if 0 < r < np.inf])
         all_summaries.append(self.log_histogram('update_ratios_log10', ratios))
         return tf.Summary(value=all_summaries)

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -363,7 +363,7 @@ class TFProcess:
         all_summaries = [
             tf.Summary.Value(tag='update_ratios/' +
                              tensor.name, simple_value=ratio)
-            for tensor, ratio in zip(self.weights, ratios) if not 'running' in tensor.name]
+            for tensor, ratio in zip(self.weights, ratios) if not 'moving' in tensor.name]
         ratios = [r for r in ratios if r < np.inf]
         all_summaries.append(self.log_histogram('update_ratios', ratios))
         return tf.Summary(value=all_summaries)

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -359,12 +359,12 @@ class TFProcess:
                   before in zip(after_weights, before_weights)]
         delta_norms = [np.linalg.norm(d.ravel()) for d in deltas]
         weight_norms = [np.linalg.norm(w.ravel()) for w in before_weights]
-        ratios = [d / w for d, w in zip(delta_norms, weight_norms)]
+        ratios = [(tensor.name, d / w) for d, w, tensor in zip(delta_norms, weight_norms, self.weights) if not 'moving' in tensor.name]
         all_summaries = [
             tf.Summary.Value(tag='update_ratios/' +
                              tensor.name, simple_value=ratio)
-            for tensor, ratio in zip(self.weights, ratios) if not 'moving' in tensor.name]
-        ratios = np.log10([r for r in ratios if 0 < r < np.inf])
+            for tensor, ratio in ratios]
+        ratios = np.log10([r for (_, r) in ratios if 0 < r < np.inf])
         all_summaries.append(self.log_histogram('update_ratios_log10', ratios))
         return tf.Summary(value=all_summaries)
 

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -364,8 +364,8 @@ class TFProcess:
             tf.Summary.Value(tag='update_ratios/' +
                              tensor.name, simple_value=ratio)
             for tensor, ratio in zip(self.weights, ratios) if not 'moving' in tensor.name]
-        ratios = [r for r in ratios if r < np.inf]
-        all_summaries.append(self.log_histogram('update_ratios', ratios))
+        ratios = np.log10([r for r in ratios if 0 < r < np.inf])
+        all_summaries.append(self.log_histogram('update_ratios_log10', ratios))
         return tf.Summary(value=all_summaries)
 
     def log_histogram(self, tag, values, bins=1000):

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -323,8 +323,7 @@ class TFProcess:
         sum_accuracy = 0
         sum_mse = 0
         sum_policy = 0
-        for _ in range(0, 50):
-#        for _ in range(0, test_batches):
+        for _ in range(0, test_batches):
             test_policy, test_accuracy, test_mse, _ = self.session.run(
                 [self.policy_loss, self.accuracy, self.mse_loss,
                  self.next_batch],


### PR DESCRIPTION
See #42. This also puts the update ratios into a histogram/distribution so that it's easier to view them across the whole network. Running mean and running variance are excluded since they are independent of learning rate.