### PR TITLE
Wip: add custom binary format that is 7% smaller than protobuf

### DIFF
--- a/tf/net.py
+++ b/tf/net.py
@@ -100,10 +100,10 @@ class Net:
         result = np.delete(result, zeroes)
         
         with bz2.open(filename, 'wb') as out:
-            version = int(3).tobytes(4, 'little')
-            array_num = int(len(weights)).frombytes(4, 'little')
+            version = int(3).to_bytes(4, 'little')
+            array_num = int(len(weights)).to_bytes(4, 'little')
             for weight in weights:
-                out.write(int(len(weight)).tobytes(4, 'little'))
+                out.write(int(len(weight)).to_bytes(4, 'little'))
             out.write(result.tobytes())
 
         size = os.path.getsize(filename) / 1024**2


### PR DESCRIPTION
the new format is
version, number of arrays, array 1 length ... array n length followed by a heavily compressed 1d array containing all the actual numbers.

Advantages:
1.  7% smaller (tested on 20b nets)
2.  Guaranteed absolute error < 2**-18
3. Allows differences between adjacent nets to be compressed down an extra 25%

Disadvantages:
1. Currently a little slow (numpy wizards help plz)
2. Probably uses more memory than required to compress and decompress.