### PR TITLE
SWA, attempt 2

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -68,7 +68,7 @@ class TFProcess:
 
         self.swa_enabled = self.cfg['training']['swa']
 
-        # Limit momentum of SWA exponential average to 1 - 1/swa_max_n
+        # Limit momentum of SWA exponential average to 1 - 1/(swa_max_n + 1)
         self.swa_max_n = self.cfg['training']['swa_max_n']
 
         gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.90, allow_growth=True, visible_device_list="{}".format(self.cfg['gpu']))

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -348,13 +348,15 @@ class TFProcess:
             swa_path = path + "-swa-" + str(steps)
             self.net.pb.training_params.training_steps = steps
             self.save_leelaz_weights(leela_path) 
-            self.save_swa_weights(swa_path)
             print("Weights saved in file: {}".format(leela_path))
-            print("SWA Weights saved in file: {}".format(swa_path))
+            if self.swa_enabled:
+                self.save_swa_weights(swa_path)
+                print("SWA Weights saved in file: {}".format(swa_path))
 
     def calculate_test_summaries(self, test_batches, steps):
-        self.snap_save()
-        self.session.run(self.swa_load_op)
+        if self.swa_enabled:
+            self.snap_save()
+            self.session.run(self.swa_load_op)
 
         sum_accuracy = 0
         sum_mse = 0
@@ -386,7 +388,8 @@ class TFProcess:
         print("step {}, policy={:g} training accuracy={:g}%, mse={:g}".\
             format(steps, sum_policy, sum_accuracy, sum_mse))
 
-        self.snap_restore()
+        if self.swa_enabled:
+            self.snap_restore()
 
     def compute_update_ratio(self, before_weights, after_weights):
         """Compute the ratio of gradient norm to weight norm.

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -364,6 +364,7 @@ class TFProcess:
         self.snap_save()
         self.session.run(self.swa_load_op)
         true_test_writer, self.test_writer = self.test_writer, self.swa_writer
+        print('swa', end=' ')
         self.calculate_test_summaries(test_batches, steps)
         self.test_writer = true_test_writer
         self.snap_restore()

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -456,13 +456,13 @@ class TFProcess:
                 v = tf.Variable(var, name='save/'+name, trainable=False)
                 save_ops.append(tf.assign(v, var))
                 rest_ops.append(tf.assign(var, v))
-            self.save_op = tf.group(*save_ops)
-            self.restore_op = tf.group(*rest_ops)
-        self.session.run(self.save_op)
+            self.snap_save_op = tf.group(*save_ops)
+            self.snap_restore_op = tf.group(*rest_ops)
+        self.session.run(self.snap_save_op)
 
     def snap_restore(self):
         # Restore variables in the current graph from the snapshot.
-        self.session.run(self.restore_op)
+        self.session.run(self.snap_restore_op)
 
     def save_swa_weights(self, filename):
         self.snap_save()

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -66,10 +66,10 @@ class TFProcess:
         # For exporting
         self.weights = []
 
-        self.swa_enabled = self.cfg['training']['swa']
+        self.swa_enabled = self.cfg['training'].get('swa', False)
 
         # Limit momentum of SWA exponential average to 1 - 1/(swa_max_n + 1)
-        self.swa_max_n = self.cfg['training']['swa_max_n']
+        self.swa_max_n = self.cfg['training'].get('swa_max_n', 0)
 
         gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.90, allow_growth=True, visible_device_list="{}".format(self.cfg['gpu']))
         config = tf.ConfigProto(gpu_options=gpu_options)

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -330,7 +330,7 @@ class TFProcess:
             self.last_steps = steps
             self.avg_policy_loss, self.avg_mse_loss, self.avg_reg_term = [], [], []
 
-        if self.swa_enabled and steps % self.cfg['training']['swa_steps'] != 0:
+        if self.swa_enabled and steps % self.cfg['training']['swa_steps'] == 0:
             self.update_swa()
 
         # Calculate test values every 'test_steps', but also ensure there is

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -71,9 +71,6 @@ class TFProcess:
         # Limit momentum of SWA exponential average to 1 - 1/swa_max_n
         self.swa_max_n = self.cfg['training']['swa_max_n']
 
-        # Net sampling rate (e.g 2 == every 2nd network).
-        self.swa_c = self.cfg['training']['swa_steps']
-
         gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.90, allow_growth=True, visible_device_list="{}".format(self.cfg['gpu']))
         config = tf.ConfigProto(gpu_options=gpu_options)
         self.session = tf.Session(config=config)

--- a/tf/train.py
+++ b/tf/train.py
@@ -133,7 +133,7 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-    num_evals = num_test*10 // ChunkParser.BATCH_SIZE
+    num_evals = num_test // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)

--- a/tf/train.py
+++ b/tf/train.py
@@ -133,7 +133,8 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-    num_evals = num_test*10 // ChunkParser.BATCH_SIZE
+#    num_evals = num_test // ChunkParser.BATCH_SIZE
+    num_evals = 4
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)

--- a/tf/train.py
+++ b/tf/train.py
@@ -133,8 +133,7 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-#    num_evals = num_test // ChunkParser.BATCH_SIZE
-    num_evals = 4
+    num_evals = num_test // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)

--- a/tf/train.py
+++ b/tf/train.py
@@ -133,7 +133,7 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-    num_evals = num_test // ChunkParser.BATCH_SIZE
+    num_evals = num_test*10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)


### PR DESCRIPTION
This is a follow-up to https://github.com/LeelaChessZero/lczero-training/pull/38 with only the SWA parts pulled out and slightly refactored to be nicer. I took out the change to LR schedule for now as it isn't required for SWA (but the paper does say that it works well with cyclical learning rates).

A potential issue with Error's previous code was that swa_cycle (now renamed to swa_steps) -- how many steps between SWA updates there are -- was coupled with swa_max_n -- the maximum momentum term of the exponential moving average in the SWA. The SWA paper only updates the SWA weights at the end of each epoch (thousands or more steps) and has max_n at 40. Any suggestions for better names than swa_max_n, since it isn't a hard cut-off?

The original implementation was slow (less than half the positions/s than before on a 10b network) due to a `self.session.run(tf.assign_add(..., ...))` call having a massive overhead despite being a single operation. I avoided this by not keeping state of how many steps there are left until the next SWA update and instead just updating when `steps % <swa_steps> == 0`.

I removed the recalculating of the BN moving mean and variances for now, it increases time to create an SWA network a lot for probably not much benefit.  

The additional config needed is:
```yaml
     swa: True  # stochastic weight averaging
     swa_steps: 500  # frequency of updates to SWA network in iterations
     swa_max_n: 20  # limit momentum term to 1 - 1/swa_max_n after swa_max_n updates
```