### PR TITLE
Add Docker Compose files and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Training data
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Training data
+data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM tensorflow/tensorflow:latest-gpu-py3
+
+RUN apt-get update
+RUN apt-get install -y protobuf-compiler
+
+RUN pip install pyyaml
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ The training pipeline resides in `tf`, this requires tensorflow running on linux
 
 ## Installation
 
-Install the requirements under `tf/requirements.txt`. And call `./init.sh` to compile the protobuf files.
+* Install the requirements under `tf/requirements.txt`
+* Get the protobufs with `git submodule update --init --recursive`
+* Call `./init.sh` to compile the protobuf files.
+
+You can also use a preconfigured Docker image if you have Docker Compose and nvidia-docker:
+* Put your training data in a top-level `data/` directory inside this repo
+* [Set the default Docker runtime to nvidia-docker](https://stackoverflow.com/questions/47465696/how-do-i-specify-nvidia-runtime-from-docker-compose-yml/47495905#47495905)
+* Run `docker-compose build && docker-compose run trainer`
+* This will open a bash shell with the source mounted under `/src`
+* Run `./init.sh` to compile protobufs.
 
 ## Data preparation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+        trainer:
+                build: .
+                entrypoint: ./docker_entrypoint.sh
+                working_dir: /src
+                volumes:
+                        - .:/src:cached

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Make sure nvidia-docker is working
+nvidia-smi
+exec bash


### PR DESCRIPTION
I was having trouble setting up dependencies, so I added a Dockerfile to install them automatically, as well as a Docker Compose file to automatically mount the git repo inside the container.

I also added `data/` to `.gitignore` (and `.dockerignore`) so it's easier to work with training data without leaving the repo directory.

I hope this helps people get started faster! It definitely helped me 😄 