### PR TITLE
Support V4TrainingData

### DIFF
--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -115,7 +115,7 @@ class ChunkParser:
         struct.Struct doesn't pickle, so it needs to be separately
         constructed in workers.
 
-        V3 Format (8276 bytes total)
+        V3 Format (8292 bytes total)
             int32 version (4 bytes)
             1858 float32 probabilities (7432 bytes)  (removed 66*4 = 264 bytes unused under-promotions)
             104 (13*8) packed bit planes of 8 bytes each (832 bytes)  (no rep2 plane)
@@ -158,7 +158,7 @@ class ChunkParser:
         """
         Unpack a v4 binary record to 4-tuple (state, policy pi, result, q)
 
-        v4 struct format is (8280 bytes total)
+        v4 struct format is (8292 bytes total)
             int32 version (4 bytes)
             1858 float32 probabilities (7432 bytes)
             104 (13*8) packed bit planes of 8 bytes each (832 bytes)
@@ -350,7 +350,7 @@ class ChunkParserTest(unittest.TestCase):
         """
         Test struct size
         """
-        self.assertEqual(self.v4_struct.size, 8280)
+        self.assertEqual(self.v4_struct.size, 8292)
 
 
     def test_parsing(self):

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -222,7 +222,7 @@ class ChunkParser:
                 # Downsample, using only 1/Nth of the items.
                 if random.randint(0, self.sample-1) != 0:
                     continue  # Skip this record.
-            record = chunkdata[i:i+self.v4_struct.size]
+            record = chunkdata[i:i+record_size]
             if version == V3_VERSION:
                 # add 16 bytes of fake root_q, best_q, root_d, best_d to match V4 format
                 chunkdata += 16 * b'\x00'

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -145,7 +145,7 @@ class ChunkParser:
         winner = tf.reshape(winner, (ChunkParser.BATCH_SIZE, 1))
         q = tf.reshape(q, (ChunkParser.BATCH_SIZE, 1))
 
-        return (planes, probs, q)
+        return (planes, probs, winner, q)
 
 
     def convert_v4_to_tuple(self, content):

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -115,7 +115,7 @@ class ChunkParser:
         struct.Struct doesn't pickle, so it needs to be separately
         constructed in workers.
 
-        V3 Format (8292 bytes total)
+        V4 Format (8292 bytes total)
             int32 version (4 bytes)
             1858 float32 probabilities (7432 bytes)  (removed 66*4 = 264 bytes unused under-promotions)
             104 (13*8) packed bit planes of 8 bytes each (832 bytes)  (no rep2 plane)

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -28,7 +28,7 @@ import unittest
 
 V3_VERSION = struct.pack('i', 3)
 V4_VERSION = struct.pack('i', 4)
-V4_STRUCT_STRING = '4s7432s832sBBBBBBBbff'
+V4_STRUCT_STRING = '4s7432s832sBBBBBBBbffff'
 V3_STRUCT_STRING = '4s7432s832sBBBBBBBb'
 
 # Interface for a chunk data source.
@@ -127,7 +127,10 @@ class ChunkParser:
             uint8 rule50_count (1 byte)
             uint8 move_count (1 byte)
             int8 result (1 byte)
-            float32 q (4 bytes)
+            float32 root_q (4 bytes)
+            float32 best_q (4 bytes)
+            float32 root_d (4 bytes)
+            float32 best_d (4 bytes)
         """
         self.v4_struct = struct.Struct(V4_STRUCT_STRING)
         self.v3_struct = struct.Struct(V3_STRUCT_STRING)
@@ -169,8 +172,10 @@ class ChunkParser:
             int8 result (1 byte)
             float32 root_q (4 bytes)
             float32 best_q (4 bytes)
+            float32 root_d (4 bytes)
+            float32 best_d (4 bytes)
         """
-        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, stm, rule50_count, move_count, winner, root_q, best_q) = self.v4_struct.unpack(content)
+        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, stm, rule50_count, move_count, winner, root_q, best_q, root_d, best_d) = self.v4_struct.unpack(content)
         # Enforce move_count to 0
         move_count = 0
 

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -225,7 +225,7 @@ class ChunkParser:
             record = chunkdata[i:i+record_size]
             if version == V3_VERSION:
                 # add 16 bytes of fake root_q, best_q, root_d, best_d to match V4 format
-                chunkdata += 16 * b'\x00'
+                record += 16 * b'\x00'
             yield record
 
 

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -26,8 +26,8 @@ import struct
 import tensorflow as tf
 import unittest
 
-V3_VERSION = struct.pack('i', 3)
 V4_VERSION = struct.pack('i', 4)
+V3_VERSION = struct.pack('i', 3)
 V4_STRUCT_STRING = '4s7432s832sBBBBBBBbffff'
 V3_STRUCT_STRING = '4s7432s832sBBBBBBBb'
 

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -252,7 +252,7 @@ class ChunkParser:
         Read v4 records from child workers, shuffle, and yield
         records.
         """
-        sbuff = sb.ShuffleBuffer(self.shuffle_size)
+        sbuff = sb.ShuffleBuffer(self.v4_struct.size, self.shuffle_size)
         while len(self.readers):
             #for r in mp.connection.wait(self.readers):
             for r in self.readers:

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -27,7 +27,7 @@ import tensorflow as tf
 import unittest
 
 VERSION = struct.pack('i', 4)
-STRUCT_STRING = '4s7432s832sBBBBBBBbf'
+STRUCT_STRING = '4s7432s832sBBBBBBBbff'
 
 # Interface for a chunk data source.
 class ChunkDataSrc:
@@ -165,7 +165,7 @@ class ChunkParser:
             uint8 move_count (1 byte)
             int8 result (1 byte)
         """
-        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, stm, rule50_count, move_count, winner, q) = self.v4_struct.unpack(content)
+        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, stm, rule50_count, move_count, winner, root_q, best_q) = self.v4_struct.unpack(content)
         # Enforce move_count to 0
         move_count = 0
 
@@ -190,9 +190,9 @@ class ChunkParser:
         assert winner == 1.0 or winner == -1.0 or winner == 0.0
         winner = struct.pack('f', winner)
 
-        q = struct.pack('f', q)
+        best_q = struct.pack('f', best_q)
 
-        return (planes, probs, winner, q)
+        return (planes, probs, winner, best_q)
 
 
     def sample_record(self, chunkdata):

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -2019,7 +2019,8 @@ class TrainingStep:
             s += " draw\n"
         else:
             raise Exception("Invalid winner: {}".format(self.winner))
-        s += "Q = {} (diff to result: {}) \n".format(self.q, abs(self.winner - self.q))
+        s += "Root Q = {} (diff to result: {}) \n".format(self.root_q, abs(self.winner - self.root_q))
+        s += "Best Q = {} (diff to result: {}) \n".format(self.best_q, abs(self.winner - self.best_q))
         if self.us_black:
             s += "(Note the black pieces are CAPS, black moves up, but A1 is in lower left)\n"
         s += "rule50_count {} b_ooo b_oo, w_ooo, w_oo {} {} {} {}\n".format(
@@ -2064,7 +2065,7 @@ class TrainingStep:
         return "".join([plane[x:x+2] for x in reversed(range(0, len(plane), 2))])
 
     def display_v2_or_v3(self, ply, content):
-        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, us_black, rule50_count, move_count, winner, q) = self.this_struct.unpack(content)
+        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, us_black, rule50_count, move_count, winner, root_q, best_q) = self.this_struct.unpack(content)
         assert self.version == int.from_bytes(ver, byteorder="little")
         # Enforce move_count to 0
         move_count = 0
@@ -2084,7 +2085,8 @@ class TrainingStep:
         self.us_black = us_black
         self.rule50_count = rule50_count
         self.winner = winner
-        self.q = q
+        self.root_q = root_q
+        self.best_q = best_q
         for idx in range(0, len(probs), 4):
             self.probs.append(struct.unpack("f", probs[idx:idx+4])[0])
         print("ply {} move {} (Not actually part of training data)".format(

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -52,7 +52,8 @@ from collections import defaultdict
 # Also note "0002" is actually b'\0x30\0x30\0x30\0x32' (or maybe reversed?)
 # so it doesn't collide with VERSION2.
 #
-VERSION3 = chunkparser.VERSION
+VERSION3 = chunkparser.V3_VERSION
+VERSION4 = chunkparser.V4_VERSION
 
 V4_BYTES = 8284
 
@@ -2041,7 +2042,7 @@ class TrainingStep:
         top_moves = {}
         for idx, prob in enumerate(self.probs):
             # Include all moves with at least 1 visit.
-            if prob > 0.0:
+            if prob >= 0.0:
                 top_moves[idx] = prob
             sum += prob
         for idx, prob in sorted(top_moves.items(), key=lambda x:-x[1]):
@@ -2100,7 +2101,7 @@ def main(args):
             chunkdata = f.read()
             if chunkdata[0:4] == b'\1\0\0\0':
                 print("Invalid version")
-            elif chunkdata[0:4] == VERSION3:
+            elif chunkdata[0:4] in {VERSION4, VERSION3}:
                 #print("debug Version3")
                 for i in range(0, len(chunkdata), V4_BYTES):
                     ts = TrainingStep(4)

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -2066,7 +2066,7 @@ class TrainingStep:
         return "".join([plane[x:x+2] for x in reversed(range(0, len(plane), 2))])
 
     def display_v2_or_v3(self, ply, content):
-        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, us_black, rule50_count, move_count, winner, root_q, best_q) = self.this_struct.unpack(content)
+        (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, us_black, rule50_count, move_count, winner, root_q, best_q, root_d, best_d) = self.this_struct.unpack(content)
         assert self.version == int.from_bytes(ver, byteorder="little")
         # Enforce move_count to 0
         move_count = 0

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -2101,8 +2101,8 @@ def main(args):
         #print("Parsing {}".format(filename))
         with gzip.open(filename, 'rb') as f:
             chunkdata = f.read()
-            if chunkdata[0:4] in {VERSION4, VERSION3}:
-                version = chunkdata[0:4]
+            version = chunkdata[0:4]
+            if version in {VERSION4, VERSION3}:
                 if version == VERSION3:
                     record_size = V3_BYTES
                 else:

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -2067,7 +2067,7 @@ class TrainingStep:
         # This causes a vertical flip
         return "".join([plane[x:x+2] for x in reversed(range(0, len(plane), 2))])
 
-    def display_v2_or_v3(self, ply, content):
+    def display_v4(self, ply, content):
         (ver, probs, planes, us_ooo, us_oo, them_ooo, them_oo, us_black, rule50_count, move_count, winner, root_q, best_q, root_d, best_d) = self.this_struct.unpack(content)
         assert self.version == int.from_bytes(ver, byteorder="little")
         # Enforce move_count to 0
@@ -2101,9 +2101,7 @@ def main(args):
         #print("Parsing {}".format(filename))
         with gzip.open(filename, 'rb') as f:
             chunkdata = f.read()
-            if chunkdata[0:4] == b'\1\0\0\0':
-                print("Invalid version")
-            elif chunkdata[0:4] in {VERSION4, VERSION3}:
+            if chunkdata[0:4] in {VERSION4, VERSION3}:
                 version = chunkdata[0:4]
                 if version == VERSION3:
                     record_size = V3_BYTES
@@ -2114,21 +2112,9 @@ def main(args):
                     record = chunkdata[i:i+record_size]
                     if chunkdata[0:4] == VERSION3:
                         record += 16 * b'\x00'
-                    ts.display_v2_or_v3(i//record_size, record)
+                    ts.display_v4(i//record_size, record)
             else:
-                parser = chunkparser.ChunkParser(chunkparser.ChunkDataSrc([chunkdata]), workers=1)
-                gen1 = parser.convert_chunkdata_to_v2(chunkdata)
-                ply = 1
-                for t1 in gen1:
-                    ts = TrainingStep(2)
-                    ts.display_v2_or_v3(ply, t1)
-                    ply += 1
-                    # TODO maybe detect new games and reset ply count
-                    # It's informational only
-                for _ in parser.parse():
-                    # TODO: What is happening here?
-                    #print("debug drain", len(_))
-                    pass
+                print("Invalid version")
 
 if __name__ == '__main__':
     usage_str = """

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -54,7 +54,7 @@ from collections import defaultdict
 #
 VERSION3 = chunkparser.VERSION
 
-V4_BYTES = 8280
+V4_BYTES = 8284
 
 # Us   -- uppercase
 # Them -- lowercase

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -2019,7 +2019,7 @@ class TrainingStep:
             s += " draw\n"
         else:
             raise Exception("Invalid winner: {}".format(self.winner))
-        s += "Q = {} (diff to result: {}) \n".format(self.q, abs(self.winner + self.q))
+        s += "Q = {} (diff to result: {}) \n".format(self.q, abs(self.winner - self.q))
         if self.us_black:
             s += "(Note the black pieces are CAPS, black moves up, but A1 is in lower left)\n"
         s += "rule50_count {} b_ooo b_oo, w_ooo, w_oo {} {} {} {}\n".format(

--- a/tf/decode_training.py
+++ b/tf/decode_training.py
@@ -2121,7 +2121,7 @@ def main(args):
                 ply = 1
                 for t1 in gen1:
                     ts = TrainingStep(2)
-                    kts.display_v2_or_v3(ply, t1)
+                    ts.display_v2_or_v3(ply, t1)
                     ply += 1
                     # TODO maybe detect new games and reset ply count
                     # It's informational only

--- a/tf/shufflebuffer.py
+++ b/tf/shufflebuffer.py
@@ -20,21 +20,18 @@ import random
 import unittest
 
 class ShuffleBuffer:
-    def __init__(self, elem_size, elem_count):
+    def __init__(self, elem_count):
         """
             A shuffle buffer for fixed sized elements.
 
             Manages 'elem_count' items in a fixed buffer, each item being exactly
             'elem_size' bytes.
         """
-        assert elem_size > 0, elem_size
         assert elem_count > 0, elem_count
-        # Size of each element.
-        self.elem_size = elem_size
         # Number of elements in the buffer.
         self.elem_count = elem_count
         # Fixed size buffer used to hold all the element.
-        self.buffer = bytearray(elem_size * elem_count)
+        self.buffer = [None for _ in range(elem_count)]
         # Number of elements actually contained in the buffer.
         self.used = 0
 
@@ -50,7 +47,7 @@ class ShuffleBuffer:
         # so returning the last item is sufficient.
         self.used -= 1
         i = self.used
-        return self.buffer[i * self.elem_size : (i+1) * self.elem_size]
+        return self.buffer[i]
 
     def insert_or_replace(self, item):
         """
@@ -59,21 +56,18 @@ class ShuffleBuffer:
 
             If the buffer is not yet full, returns None
         """
-        assert len(item) == self.elem_size, len(item)
         # putting the new item in a random location, and appending
         # the displaced item to the end of the buffer achieves a full
         # random shuffle (Fisher-Yates)
         if self.used > 0:
             # swap 'item' with random item in buffer.
             i = random.randint(0, self.used-1)
-            old_item = self.buffer[i * self.elem_size : (i+1) * self.elem_size]
-            self.buffer[i * self.elem_size : (i+1) * self.elem_size] = item
-            item = old_item
+            item, self.buffer[i] = self.buffer[i], item
         # If the buffer isn't yet full, append 'item' to the end of the buffer.
         if self.used < self.elem_count:
             # Not yet full, so place the returned item at the end of the buffer.
             i = self.used
-            self.buffer[i * self.elem_size : (i+1) * self.elem_size] = item
+            self.buffer[i] = item
             self.used += 1
             return None
         return item

--- a/tf/shufflebuffer.py
+++ b/tf/shufflebuffer.py
@@ -20,18 +20,21 @@ import random
 import unittest
 
 class ShuffleBuffer:
-    def __init__(self, elem_count):
+    def __init__(self, elem_size, elem_count):
         """
             A shuffle buffer for fixed sized elements.
 
             Manages 'elem_count' items in a fixed buffer, each item being exactly
             'elem_size' bytes.
         """
+        assert elem_size > 0, elem_size
         assert elem_count > 0, elem_count
+        # Size of each element.
+        self.elem_size = elem_size
         # Number of elements in the buffer.
         self.elem_count = elem_count
         # Fixed size buffer used to hold all the element.
-        self.buffer = [None for _ in range(elem_count)]
+        self.buffer = bytearray(elem_size * elem_count)
         # Number of elements actually contained in the buffer.
         self.used = 0
 
@@ -47,7 +50,7 @@ class ShuffleBuffer:
         # so returning the last item is sufficient.
         self.used -= 1
         i = self.used
-        return self.buffer[i]
+        return self.buffer[i * self.elem_size : (i+1) * self.elem_size]
 
     def insert_or_replace(self, item):
         """
@@ -56,18 +59,21 @@ class ShuffleBuffer:
 
             If the buffer is not yet full, returns None
         """
+        assert len(item) == self.elem_size, len(item)
         # putting the new item in a random location, and appending
         # the displaced item to the end of the buffer achieves a full
         # random shuffle (Fisher-Yates)
         if self.used > 0:
             # swap 'item' with random item in buffer.
             i = random.randint(0, self.used-1)
-            item, self.buffer[i] = self.buffer[i], item
+            old_item = self.buffer[i * self.elem_size : (i+1) * self.elem_size]
+            self.buffer[i * self.elem_size : (i+1) * self.elem_size] = item
+            item = old_item
         # If the buffer isn't yet full, append 'item' to the end of the buffer.
         if self.used < self.elem_count:
             # Not yet full, so place the returned item at the end of the buffer.
             i = self.used
-            self.buffer[i] = item
+            self.buffer[i * self.elem_size : (i+1) * self.elem_size] = item
             self.used += 1
             return None
         return item

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -93,6 +93,7 @@ class TFProcess:
         self.x = next_batch[0]  # tf.placeholder(tf.float32, [None, 112, 8*8])
         self.y_ = next_batch[1] # tf.placeholder(tf.float32, [None, 1858])
         self.z_ = next_batch[2] # tf.placeholder(tf.float32, [None, 1])
+        self.q_ = next_batch[3] # tf.placeholder(tf.float32, [None, 1])
         self.batch_norm_count = 0
         self.y_conv, self.z_conv = self.construct_net(self.x)
 
@@ -103,8 +104,9 @@ class TFProcess:
         self.policy_loss = tf.reduce_mean(cross_entropy)
 
         # Loss on value head
+        target = self.q_
         self.mse_loss = \
-            tf.reduce_mean(tf.squared_difference(self.z_, self.z_conv))
+            tf.reduce_mean(tf.squared_difference(target, self.z_conv))
 
         # Regularizer
         regularizer = tf.contrib.layers.l2_regularizer(scale=0.0001)

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -109,7 +109,7 @@ class TFProcess:
         self.policy_loss = tf.reduce_mean(cross_entropy)
 
         # Loss on value head
-        q_ratio = self.cfg['training']['q_ratio']
+        q_ratio = self.cfg['training'].get('q_ratio', 0)
         assert 0 <= q_ratio <= 1
         target = self.q_ * q_ratio + self.z_ * (1 - q_ratio)
         self.mse_loss = \

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -104,7 +104,9 @@ class TFProcess:
         self.policy_loss = tf.reduce_mean(cross_entropy)
 
         # Loss on value head
-        target = self.q_
+        q_ratio = self.cfg['training']['q_ratio']
+        assert 0 <= q_ratio <= 1
+        target = self.q_ * q_ratio + self.z_ * (1 - q_ratio)
         self.mse_loss = \
             tf.reduce_mean(tf.squared_difference(target, self.z_conv))
 

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -97,6 +97,9 @@ class TFProcess:
         self.batch_norm_count = 0
         self.y_conv, self.z_conv = self.construct_net(self.x)
 
+        # y_ has -1 on illegal moves, flush them to 0 first
+        self.y_ = tf.nn.relu(self.y_)
+
         # Calculate loss on policy head
         cross_entropy = \
             tf.nn.softmax_cross_entropy_with_logits(labels=self.y_,

--- a/tf/train.py
+++ b/tf/train.py
@@ -108,7 +108,7 @@ def main(cmd):
     train_parser = ChunkParser(FileDataSrc(train_chunks),
             shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE)
     dataset = tf.data.Dataset.from_generator(
-        train_parser.parse, output_types=(tf.string, tf.string, tf.string))
+        train_parser.parse, output_types=(tf.string, tf.string, tf.string, tf.string))
     dataset = dataset.map(ChunkParser.parse_function)
     dataset = dataset.prefetch(4)
     train_iterator = dataset.make_one_shot_iterator()
@@ -117,7 +117,7 @@ def main(cmd):
     test_parser = ChunkParser(FileDataSrc(test_chunks),
             shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE)
     dataset = tf.data.Dataset.from_generator(
-        test_parser.parse, output_types=(tf.string, tf.string, tf.string))
+        test_parser.parse, output_types=(tf.string, tf.string, tf.string, tf.string))
     dataset = dataset.map(ChunkParser.parse_function)
     dataset = dataset.prefetch(4)
     test_iterator = dataset.make_one_shot_iterator()

--- a/tf/train.py
+++ b/tf/train.py
@@ -133,7 +133,7 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-    num_evals = num_test//10 // ChunkParser.BATCH_SIZE
+    num_evals = num_test*10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)

--- a/tf/train.py
+++ b/tf/train.py
@@ -133,7 +133,7 @@ def main(cmd):
     # Assumes average of 10 samples per test game.
     # For simplicity, testing can use the split batch size instead of total batch size.
     # This does not affect results, because test results are simple averages that are independent of batch size.
-    num_evals = num_test*10 // ChunkParser.BATCH_SIZE
+    num_evals = num_test//10 // ChunkParser.BATCH_SIZE
     print("Using {} evaluation batches".format(num_evals))
 
     tfprocess.process_loop(total_batch_size, num_evals, batch_splits=batch_splits)


### PR DESCRIPTION
See https://github.com/LeelaChessZero/lc0/pull/722.
This is backwards compatible to loading V3TrainingData by setting root_q, best_q, root_d, root_q to 0.0 and not masking away illegal moves. Setting q_ratio in the interval [0, 1] (default 0) allows adjustment of how much q is mixed into z. In training, this PR changes nothing by default.

I started a training run on CCRL with v3 data and it hasn't broken at 1000 steps yet.