### PR TITLE
Add some useful scripts

### DIFF
--- a/scripts/fixorder.py
+++ b/scripts/fixorder.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import argparse
+
+
+def get_sorted_chunk_ids(dirs):
+    ids = []
+    for d in dirs:
+        for f in glob.glob(os.path.join(d, "training.*.gz")):
+            ids.append(int(os.path.basename(f).split('.')[-2]))
+    ids.sort()
+    return ids
+
+
+def main(argv):
+    a = get_sorted_chunk_ids([argv.input])
+    for i in a:
+        os.utime(os.path.join(argv.input, "training.{}.gz".format(i)), None)
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(description=\
+            'Change modification time on training files to match their numeric order.')
+    argparser.add_argument('-i', '--input', type=str,
+            help='input directory')
+
+    main(argparser.parse_args())

--- a/scripts/initsplit.py
+++ b/scripts/initsplit.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import argparse
+
+
+def get_sorted_chunk_ids(dirs):
+    ids = []
+    for d in dirs:
+        for f in glob.glob(os.path.join(d, "training.*.gz")):
+            ids.append(int(os.path.basename(f).split('.')[-2]))
+    ids.sort(reverse=True)
+    return ids
+
+
+def main(argv):
+    a = get_sorted_chunk_ids([argv.input])
+    n = min(argv.wsize, len(a))
+    for i in sorted(a[:n]):
+        if i % 100 >= 90:
+            os.link(os.path.join(argv.input, "training.{}.gz".format(i)), os.path.join(argv.output, "test/training.{}.gz".format(i)))
+        else:
+            os.link(os.path.join(argv.input, "training.{}.gz".format(i)), os.path.join(argv.output, "train/training.{}.gz".format(i)))
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(description=\
+            'Link input to test/train subdirectories of output in 10:90 ratio.')
+    argparser.add_argument('-i', '--input', type=str,
+            help='input directory')
+    argparser.add_argument('-w', '--wsize', type=int,
+            help='window size - should be padded a bit to ensure both sides of split exceed fraction of target')
+    argparser.add_argument('-o', '--output', type=str,
+            help='output directory')
+
+    main(argparser.parse_args())

--- a/scripts/rescore.sh
+++ b/scripts/rescore.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+ROOT="/work/lc0/dev2"
+RESCORER="$HOME/bin/rescorer"
+
+function usage()
+{
+  echo "Rescores stuff"
+  echo ""
+  echo "./rescore.sh"
+  echo "  -h --help"
+  echo ""
+  echo "Example: ./rescore.sh"
+  echo ""
+}
+
+while [ "$1" != "" ]
+do
+  PARAM=`echo $1 | awk -F= '{print $1}'`
+  VALUE=`echo $1 | awk -F= '{print $2}'`
+  case $PARAM in
+    -h | --help)
+      usage
+      exit
+      ;;
+    *)
+      echo "ERROR: unknown parameter \"$PARAM\""
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+rescore() {
+  unbuffer $RESCORER rescore --threads=4 --syzygy-paths=/work/lc0/syzygy/:/wdl/syzygy/wdl/:/wdl/syzygy/dtz/ --input="$ROOT/data-staged" --output="$ROOT/data-rescored" 2>&1 | tee "$ROOT/rescore-logs/$(date +%Y%m%d-%H%M%S).log"
+}
+
+while true
+do
+  rescore
+  echo -n "."
+  sleep 10
+done

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage()
+{
+  echo "Moves arriving data to a directory so rescorer can assume all files are complete"
+  echo ""
+  echo "./stage.sh"
+  echo "  -h --help"
+  echo "  -i --input   The monitoring directory"
+  echo "  -o --output   The directory where output should go"
+  echo ""
+  echo "Example: ./stage.sh -i data -o data-staged"
+  echo ""
+}
+
+while [ "$1" != "" ]
+do
+  PARAM=`echo $1 | awk -F= '{print $1}'`
+  VALUE=`echo $1 | awk -F= '{print $2}'`
+  case $PARAM in
+    -h | --help)
+      usage
+      exit
+      ;;
+    -i | --input)
+      INPUTDIR=$VALUE
+      ;;
+    -o | --output)
+      OUTPUTDIR=$VALUE
+      ;;
+    *)
+      echo "ERROR: unknown parameter \"$PARAM\""
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+
+echo "start data monitor for $INPUTDIR"
+
+inotifywait -m -e moved_to -e close_write $INPUTDIR | mbuffer -m 10M |
+  while read dir events file
+  do
+    if [[ $file = *.gz ]]
+    then
+      echo -n "."
+      mv "$INPUTDIR/$file" "$OUTPUTDIR/"
+    #else
+      #echo "ignoring ${file} ($events)"
+    fi
+  done


### PR DESCRIPTION
fixorder.py is useful when starting training for the first time and rescoring has messed with the timestamps on the files so they don't match the numerical order anymore.
initsplit.py is a super fast alternative to split.sh that works as a once off when setting up training for the first time.
rescore.sh runs rescorer in a loop - should take more parameters...
stage.sh watches file system events and moves files to a different directory (on the same file system) so that rescorer never tries to rescore a partially written file.