### PR TITLE
Bug in policy format initialisation

### DIFF
--- a/tf/net.py
+++ b/tf/net.py
@@ -35,7 +35,7 @@ class Net:
 
         self.set_networkformat(net)
         self.pb.format.network_format.input = input
-        self.set_policyformat(value)
+        self.set_policyformat(policy)
         self.set_valueformat(value)
 
     def set_networkformat(self, net):


### PR DESCRIPTION
At the moment the code works because `pb.NetworkFormat.VALUE_CLASSICAL == pb.NetworkFormat.POLICY_CLASSICAL == 0`. But at some point this will change, and then it will break.