### PR TITLE
Randomly flip training positions

### DIFF
--- a/tf/train.py
+++ b/tf/train.py
@@ -129,6 +129,7 @@ def main(cmd):
     allow_less = cfg['dataset'].get('allow_less_chunks', False)
     train_ratio = cfg['dataset']['train_ratio']
     experimental_parser = cfg['dataset'].get('experimental_v4_only_dataset', False)
+    flip = cfg['dataset']['flip_augmentation']
     num_train = int(num_chunks*train_ratio)
     num_test = num_chunks - num_train
     if 'input_test' in cfg['dataset']:
@@ -163,7 +164,8 @@ def main(cmd):
                          .batch(split_batch_size).map(extract_inputs_outputs).prefetch(4)
     else:
         train_parser = ChunkParser(FileDataSrc(train_chunks),
-                shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE)
+                shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE,
+                flip=flip)
         train_dataset = tf.data.Dataset.from_generator(
             train_parser.parse, output_types=(tf.string, tf.string, tf.string, tf.string))
         train_dataset = train_dataset.map(ChunkParser.parse_function)
@@ -177,7 +179,8 @@ def main(cmd):
                          .batch(split_batch_size).map(extract_inputs_outputs).prefetch(4)
     else:
         test_parser = ChunkParser(FileDataSrc(test_chunks),
-                shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE)
+                shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE,
+                flip=False)
         test_dataset = tf.data.Dataset.from_generator(
             test_parser.parse, output_types=(tf.string, tf.string, tf.string, tf.string))
         test_dataset = test_dataset.map(ChunkParser.parse_function)


### PR DESCRIPTION
When castling is not possible randomly flip the board including policy probabilities.

Currently this seems to result in a weaker net:
```
   # PLAYER              :  RATING  ERROR  POINTS  PLAYED   (%)  CFS(%)    W    D    L  D(%)
   1 lc0_no_flip_200k    :     0.0    7.9   530.5    1000    53     100  325  411  264    41
   2 lc0_flip_200k       :   -21.5    7.9   469.5    1000    47     ---  264  411  325    41
fixed 800 nodes.
```

Since castling is determined from the current position history may contain positions where king is on the wrong square. Some positions are not equally likely to be encountered in match play in a flipped state and it's probably not useful to train NN on those cases. This probably makes more sense when training with Fischer random training data. For ordinary chess more care should be used to determine if position can be flipped.