### PR TITLE
Return to using default number of buckets for weight histogram

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -558,7 +558,7 @@ class TFProcess:
             if self.wdl:
                 tf.summary.scalar("Value Accuracy", sum_value_accuracy, step=steps)
             for w in self.model.weights:
-                tf.summary.histogram(w.name, w, buckets=1000, step=steps)
+                tf.summary.histogram(w.name, w, step=steps)
         self.test_writer.flush()
 
         print("step {}, policy={:g} value={:g} policy accuracy={:g}% value accuracy={:g}% mse={:g}".\


### PR DESCRIPTION
I'm not certain this is actually identical to the pre v2 conversion, but definitely the old code was not specifying a number of buckets - so I am guessing the old code default buckets is the same number as the new code default buckets...

This should result in a 30 fold reduction in tensorboard logging size for the test steps - which should bring it closer in size to the train ones.