### PR TITLE
Direct to protobuf save and replace

### DIFF
--- a/tf/net.py
+++ b/tf/net.py
@@ -11,6 +11,11 @@ LC0_MINOR = 21
 LC0_PATCH = 0
 WEIGHTS_MAGIC = 0x1c0
 
+def nested_getattr(obj, attr):
+    attributes = attr.split(".")
+    for a in attributes:
+        obj = getattr(obj, a)
+    return obj
 
 class Net:
     def __init__(self,
@@ -65,6 +70,21 @@ class Net:
         else:
             return {"input": 4, "residual": 8, "head": head_weights}
 
+
+    def fill_layer_v2(self, layer, params):
+        """Normalize and populate 16bit layer in protobuf"""
+        params = params.flatten().astype(np.float32)
+        layer.min_val = 0 if len(params) == 1 else float(np.min(params))
+        layer.max_val = 1 if len(params) == 1 and np.max(params) == 0 else float(np.max(params))
+        if layer.max_val == layer.min_val:
+            # Avoid division by zero if max == min.
+            params = (params - layer.min_val)
+        else:
+            params = (params - layer.min_val) / (layer.max_val - layer.min_val)
+        params *= 0xffff
+        params = np.round(params)
+        layer.params = params.astype(np.uint16).tobytes()
+
     def fill_layer(self, layer, weights):
         """Normalize and populate 16bit layer in protobuf"""
         params = np.array(weights.pop(), dtype=np.float32)
@@ -104,11 +124,14 @@ class Net:
         self.fill_layer(se_unit.b1, weights)
         self.fill_layer(se_unit.w1, weights)
 
-    def denorm_layer(self, layer, weights):
+    def denorm_layer_v2(self, layer):
         """Denormalize a layer from protobuf"""
         params = np.frombuffer(layer.params, np.uint16).astype(np.float32)
         params /= 0xffff
-        weights.insert(0, params * (layer.max_val - layer.min_val) + layer.min_val)
+        return params * (layer.max_val - layer.min_val) + layer.min_val
+
+    def denorm_layer(self, layer, weights):
+        weights.insert(0, self.denorm_layer_v2(layer))
 
     def denorm_conv_block(self, convblock, weights):
         """Denormalize a convblock from protobuf"""
@@ -178,6 +201,113 @@ class Net:
         size = os.path.getsize(filename) / 1024**2
         print("Weights saved as '{}' {}M".format(filename, round(size, 2)))
 
+    def tf_name_to_pb_name(self, name):
+        """Given Tensorflow variable name returns the protobuf name and index
+        of residual block if weight belong in a residual block."""
+
+        def convblock_to_bp(w):
+            w = w.split(':')[0]
+            d = {'kernel':'weights', 'gamma':'bn_gammas', 'beta':'bn_betas',
+                    'moving_mean':'bn_means', 'moving_variance':'bn_stddivs',
+                    'bias':'biases'}
+
+            return d[w]
+
+        def se_to_bp(l, w):
+            if l == 'dense1':
+                n = 1
+            elif l == 'dense2':
+                n = 2
+            else:
+                raise ValueError('Unable to decode SE-weight {}/{}'.format(l, w))
+            w = w.split(':')[0]
+            d = {'kernel':'w', 'bias':'b'}
+
+            return d[w] + str(n)
+
+        def value_to_bp(l, w):
+            if l == 'dense1':
+                n = 1
+            elif l == 'dense2':
+                n = 2
+            else:
+                raise ValueError('Unable to decode value weight {}/{}'.format(l, w))
+            w = w.split(':')[0]
+            d = {'kernel':'ip{}_val_w', 'bias':'ip{}_val_b'}
+
+            return d[w].format(n)
+
+        def policy_to_bp(w):
+            w = w.split(':')[0]
+            d = {'kernel':'ip_pol_w', 'bias':'ip_pol_b'}
+
+            return d[w]
+
+        layers = name.split('/')
+        base_layer = layers[0]
+        weights_name = layers[-1]
+        pb_name = None
+        block = None
+
+        if base_layer == 'input':
+            pb_name = 'input.' + convblock_to_bp(weights_name)
+        elif base_layer == 'policy1':
+            pb_name = 'policy1.' + convblock_to_bp(weights_name)
+        elif base_layer == 'policy':
+            if 'dense' in layers[1]:
+                pb_name = policy_to_bp(weights_name)
+            else:
+                pb_name = 'policy.' + convblock_to_bp(weights_name)
+        elif base_layer == 'value':
+            if 'dense' in layers[1]:
+                pb_name = value_to_bp(layers[1], weights_name)
+            else:
+                pb_name = 'value.' + convblock_to_bp(weights_name)
+        elif base_layer.startswith('residual'):
+            block = int(base_layer.split('_')[1]) - 1 # 1 indexed
+            if layers[1] == '1':
+                pb_name = 'conv1.' + convblock_to_bp(weights_name)
+            elif layers[1] == '2':
+                pb_name = 'conv2.' + convblock_to_bp(weights_name)
+            elif layers[1] == 'se':
+                pb_name = 'se.' + se_to_bp(layers[-2], weights_name)
+
+        return (pb_name, block)
+
+    def get_weights_v2(self, names):
+        # `names` is a list of Tensorflow tensor names to get from the protobuf.
+        # Returns list of [Tensor name, Tensor weights].
+        tensors = {}
+
+        for tf_name in names:
+
+            name = tf_name
+            if 'stddev' in name:
+                # Get variance instead of stddev.
+                name = name.replace('stddev', 'variance')
+            if 'renorm' in name:
+                # Renorm variables are not populated.
+                continue
+
+            pb_name, block = self.tf_name_to_pb_name(name)
+
+            if pb_name is None:
+                raise ValueError("Don't know where to store weight in protobuf: {}".format(name))
+
+            if block == None:
+                pb_weights = self.pb.weights
+            else:
+                pb_weights = self.pb.weights.residual[block]
+
+            w = self.denorm_layer_v2(nested_getattr(pb_weights, pb_name))
+
+            # Only variance is stored in the protobuf.
+            if 'stddev' in tf_name:
+                w = np.sqrt(w + 1e-5)
+
+            tensors[tf_name] = w
+        return tensors
+
     def get_weights(self):
         """Returns the weights as floats per layer"""
         se = self.pb.format.network_format.network == pb.NetworkFormat.NETWORK_SE_WITH_HEADFORMAT
@@ -207,19 +337,12 @@ class Net:
         return self.weights
 
     def filters(self):
-        w = self.get_weights()
-        return len(w[1])
+        layer = self.pb.weights.input.bn_means
+        params = np.frombuffer(layer.params, np.uint16).astype(np.float32)
+        return len(params)
 
     def blocks(self):
-        w = self.get_weights()
-
-        ws = self.get_weight_amounts()
-        blocks = len(w) - (ws['input'] + ws['head'])
-
-        if blocks % ws['residual'] != 0:
-            raise ValueError("Inconsistent number of weights in the file")
-
-        return blocks // ws['residual']
+        return len(self.pb.weights.residual)
 
     def print_stats(self):
         print("Blocks: {}".format(self.blocks()))
@@ -260,6 +383,74 @@ class Net:
             self.set_policyformat(pb.NetworkFormat.POLICY_CONVOLUTION)
 
         self.fill_net(weights)
+
+    def fill_net_v2(self, all_weights):
+        # all_weights is array of [name of weight, numpy array of weights].
+        self.pb.format.weights_encoding = pb.Format.LINEAR16
+
+        has_renorm = any('renorm' in w[0] for w in all_weights)
+        weight_names = [w[0] for w in all_weights]
+
+        del self.pb.weights.residual[:]
+
+        for name, weights in all_weights:
+            layers = name.split('/')
+            weights_name = layers[-1]
+            if weights.ndim == 4:
+                # Convolution weights need a transpose
+                #
+                # TF
+                # [filter_height, filter_width, in_channels, out_channels]
+                #
+                # Leela
+                # [output, input, filter_size, filter_size]
+                weights = np.transpose(weights, axes=[3, 2, 0, 1])
+            elif weights.ndim == 2:
+                # Fully connected layers are [in, out] in TF
+                #
+                # [out, in] in Leela
+                #
+                weights = np.transpose(weights, axes=[1, 0])
+
+            if 'renorm' in name:
+                # Batch renorm has extra weights, but we don't know what to do with them.
+                continue
+            if has_renorm:
+                if 'variance:' in weights_name:
+                    # Renorm has variance, but it is not the primary source of truth.
+                    continue
+                # Renorm has moving stddev not variance, undo the transform to make it compatible.
+                if 'stddev:' in weights_name:
+                    weights = np.square(weights) - 1e-5
+                    name = name.replace('stddev', 'variance')
+
+            if name == 'input/conv2d/kernel:0':
+                # 50 move rule is the 110th input, or 109 starting from 0.
+                weights[:, 109, :, :] /= 99
+
+            pb_name, block = self.tf_name_to_pb_name(name)
+
+            if pb_name is None:
+                raise ValueError("Don't know where to store weight in protobuf: {}".format(name))
+
+            if block == None:
+                pb_weights = self.pb.weights
+            else:
+                assert block >= 0
+                while block >= len(self.pb.weights.residual):
+                    self.pb.weights.residual.add()
+                pb_weights = self.pb.weights.residual[block]
+
+            self.fill_layer_v2(nested_getattr(pb_weights, pb_name), weights)
+
+            if pb_name.endswith('bn_betas'):
+                # Check if we need to add constant one gammas.
+                gamma_name = name.replace('beta', 'gamma')
+                if gamma_name in weight_names:
+                    continue
+                gamma = np.ones(weights.shape)
+                pb_gamma = pb_name.replace('bn_betas', 'bn_gammas')
+                self.fill_layer_v2(nested_getattr(pb_weights, pb_gamma), gamma)
 
     def fill_net(self, weights):
         self.weights = []

--- a/tf/net.py
+++ b/tf/net.py
@@ -280,7 +280,6 @@ class Net:
         tensors = {}
 
         for tf_name in names:
-
             name = tf_name
             if 'stddev' in name:
                 # Get variance instead of stddev.

--- a/tf/net_to_model.py
+++ b/tf/net_to_model.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import tensorflow as tf
 import os
 import yaml
 import tfprocess
@@ -17,19 +16,10 @@ args = argparser.parse_args()
 cfg = yaml.safe_load(args.cfg.read())
 print(yaml.dump(cfg, default_flow_style=False))
 START_FROM = args.start
-net = Net()
-net.parse_proto(args.net)
-
-filters, blocks = net.filters(), net.blocks()
-if cfg['model']['filters'] != filters:
-    raise ValueError("Number of filters in YAML doesn't match the network")
-if cfg['model']['residual_blocks'] != blocks:
-    raise ValueError("Number of blocks in YAML doesn't match the network")
-weights = net.get_weights()
 
 tfp = tfprocess.TFProcess(cfg)
 tfp.init_net_v2()
-tfp.replace_weights_v2(weights)
+tfp.replace_weights_v2(args.net)
 tfp.global_step.assign(START_FROM)
 
 root_dir = os.path.join(cfg['training']['path'], cfg['name'])


### PR DESCRIPTION
Removes the step where weights are stored in list and instead writes them directly to protobuf based on Tensorflow variable names. Fixes classical policy head support.

Tested successfully shortly training from scratch and `net_to_model` from existing network with and without renorm.

Also some other formatting fixes. Removing backslashes fixes some graph optimizer error messages. There was a tensorflow bug report about it, but I can't find it right now.