### PR TITLE
Less memory intensive input pipeline

### DIFF
--- a/scripts/shuffle.py
+++ b/scripts/shuffle.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+import gzip
+import sys
+import glob
+import os
+import random
+from multiprocessing import Pool
+import tqdm
+
+merge_files = 100
+processes = 8
+shuffle = True
+record_length = 8292
+
+def split(a, n):
+    k, m = divmod(len(a), n)
+    return [a[i * k + min(i, m):(i + 1) * k + min(i + 1, m)] for i in range(n)]
+
+def positions(chunk):
+    pos = []
+    i = 0
+    while record_length*i < len(chunk):
+        pos.append(chunk[record_length*i:record_length*(i+1)])
+        i += 1
+    return pos
+
+def shuffle(files):
+    data = []
+    for filename in files:
+        with gzip.open(filename, 'rb') as f:
+            data.extend(positions(f.read()))
+    if shuffle:
+        random.shuffle(data)
+    for d in data:
+        if d[0] != 0x04:
+            print(files)
+            raise ValueError('Wrong training data format, not V4')
+    new_file = list(os.path.splitext(files[0]))
+    new_file[0] += '_shuffled'
+    new_file = ''.join(new_file)
+    new_file_temp = new_file + '.temp'
+    with gzip.open(new_file_temp, 'wb', compresslevel=9) as f:
+        for d in data:
+            f.write(d)
+    # For interrupt safety, make sure not to write partial chunks.
+    os.rename(new_file_temp, new_file)
+    for filename in files:
+        os.remove(filename)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print('Expected one argument, got {}'.format(len(sys.argv)-1))
+        exit(1)
+    s = sys.argv[1]
+    files = glob.glob(os.path.join(sys.argv[1], '*.gz'))
+    files = [f for f in files if '_shuffled' not in f]
+    print('Found {} files'.format(len(files)))
+    if len(files) == 0:
+        exit(1)
+    files = split(files, len(files)//merge_files)
+    pool = Pool(processes)
+
+    for _ in tqdm.tqdm(pool.imap_unordered(shuffle, files), total=len(files)):
+        pass

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -25,6 +25,7 @@ import shufflebuffer as sb
 import struct
 import tensorflow as tf
 import unittest
+import gzip
 
 V4_VERSION = struct.pack('i', 4)
 V3_VERSION = struct.pack('i', 3)
@@ -42,14 +43,41 @@ class ChunkDataSrc:
 
 
 
+def chunk_reader(chunk_filenames, output_pipes):
+    """
+    Reads chunk filenames from a list and writes them in shuffled
+    order to output_pipes.
+    """
+    chunks = []
+    done = chunk_filenames
+    n = 0
+
+    while True:
+        if not chunks:
+            chunks, done = done, chunks
+            random.shuffle(chunks)
+        if not chunks:
+            print("chunk_reader didn't find any chunks.")
+            return None
+        while len(chunks):
+            filename = chunks.pop()
+            done.append(filename)
+            output_pipes[n].send(filename)
+            n += 1
+            if n >= len(output_pipes):
+                n = 0
+    print("chunk_reader exiting.")
+    return None
+
 class ChunkParser:
     # static batch size
     BATCH_SIZE = 8
-    def __init__(self, chunkdatasrc, shuffle_size=1, sample=1, buffer_size=1, batch_size=256, workers=None):
+    def __init__(self, chunks, shuffle_size=1, sample=1, buffer_size=1,
+            batch_size=256, workers=None):
         """
         Read data and yield batches of raw tensors.
 
-        'chunkdatasrc' is an object yeilding chunkdata
+        'chunks' list of chunk filenames.
         'shuffle_size' is the size of the shuffle buffer.
         'sample' is the rate to down-sample.
         'workers' is the number of child workers to use.
@@ -89,13 +117,25 @@ class ChunkParser:
         self.readers = []
         self.writers = []
         self.processes = []
+        self.chunk_writers = []
+        self.chunk_readers = []
         for _ in range(workers):
+            chunk_read, chunk_write = mp.Pipe(duplex=False)
             read, write = mp.Pipe(duplex=False)
-            p = mp.Process(target=self.task, args=(chunkdatasrc, write))
+            p = mp.Process(target=self.task, args=(chunk_read, write))
+            p.daemon = True
             self.processes.append(p)
             p.start()
             self.readers.append(read)
             self.writers.append(write)
+            self.chunk_readers.append(chunk_read)
+            self.chunk_writers.append(chunk_write)
+
+        self.chunk_process = mp.Process(target=chunk_reader, args=(chunks, self.chunk_writers))
+        self.chunk_process.daemon = True
+        self.chunk_process.start()
+
+
         self.init_structs()
 
 
@@ -108,6 +148,10 @@ class ChunkParser:
             self.processes[i].join()
             self.readers[i].close()
             self.writers[i].close()
+            self.chunk_readers[i].close()
+            self.chunk_writers[i].close()
+        self.chunk_process.terminate()
+        self.chunk_process.join()
 
 
     def init_structs(self):
@@ -232,23 +276,35 @@ class ChunkParser:
             yield record
 
 
-    def task(self, chunkdatasrc, writer):
+    def task(self, chunk_pipe, writer):
         """
         Run in fork'ed process, read data from chunkdatasrc, parsing, shuffling and
         sending v4 data through pipe back to main process.
         """
         self.init_structs()
         while True:
-            chunkdata = chunkdatasrc.next()
-            if chunkdata is None:
-                break
-            for item in self.sample_record(chunkdata):
-                # NOTE: This requires some more thinking, we can't just apply a
-                # reflection along the horizontal or vertical axes as we would
-                # also have to apply the reflection to the move probabilities
-                # which is non trivial for chess.
-                writer.send_bytes(item)
+            filename = chunk_pipe.recv()
+            try:
+                with gzip.open(filename, 'rb') as chunk_file:
+                    version = chunk_file.read(4)
+                    chunk_file.seek(0)
+                    if version == V4_VERSION:
+                        record_size = self.v4_struct.size
+                    elif version == V3_VERSION:
+                        record_size = self.v3_struct.size
+                    else:
+                        print('Unknown version {} in file {}'.format(version, filename))
+                        continue
+                    while True:
+                        chunkdata = chunk_file.read(512 * record_size)
+                        if len(chunkdata) == 0:
+                            break
+                        for item in self.sample_record(chunkdata):
+                            writer.send_bytes(item)
 
+            except:
+                print("failed to parse {}".format(filename))
+                continue
 
     def v4_gen(self):
         """

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -64,6 +64,7 @@ class TFProcess:
         self.policy_channels = self.cfg['model'].get('policy_channels', 32)
         precision = self.cfg['training'].get('precision', 'single')
         loss_scale = self.cfg['training'].get('loss_scale', 128)
+        self.virtual_batch_size = self.cfg['model'].get('virtual_batch_size', None)
 
         if precision == 'single':
             self.model_dtype = tf.float32
@@ -375,9 +376,9 @@ class TFProcess:
                 self.calculate_swa_summaries_v2(test_batches, steps + 1)
 
         # Make sure that ghost batch norm can be applied
-        if batch_size % 64 != 0:
+        if self.virtual_batch_size and batch_size % self.virtual_batch_size != 0:
             # Adjust required batch size for batch splitting.
-            required_factor = 64 * self.cfg['training'].get('num_batch_splits', 1)
+            required_factor = self.virtual_batch_size * self.cfg['training'].get('num_batch_splits', 1)
             raise ValueError(
                 'batch_size must be a multiple of {}'.format(required_factor))
 
@@ -655,8 +656,8 @@ class TFProcess:
                 renorm_momentum=self.renorm_momentum, name=name)(input)
         else:
             return tf.keras.layers.BatchNormalization(
-                epsilon=1e-5, axis=1, fused=False, center=True,
-                scale=scale, virtual_batch_size=64, name=name)(input)
+                epsilon=1e-5, axis=1, center=True, scale=scale,
+                virtual_batch_size=self.virtual_batch_size, name=name)(input)
 
     def squeeze_excitation_v2(self, inputs, channels, name):
         assert channels % self.SE_ratio == 0

--- a/tf/train.py
+++ b/tf/train.py
@@ -62,29 +62,6 @@ def get_latest_chunks(path, num_chunks, allow_less):
     random.shuffle(chunks)
     return chunks
 
-
-class FileDataSrc:
-    """
-        data source yielding chunkdata from chunk files.
-    """
-    def __init__(self, chunks):
-        self.chunks = []
-        self.done = chunks
-    def next(self):
-        if not self.chunks:
-            self.chunks, self.done = self.done, self.chunks
-            random.shuffle(self.chunks)
-        if not self.chunks:
-            return None
-        while len(self.chunks):
-            filename = self.chunks.pop()
-            try:
-                with gzip.open(filename, 'rb') as chunk_file:
-                    self.done.append(filename)
-                    return chunk_file.read()
-            except:
-                print("failed to parse {}".format(filename))
-
 def extract_inputs_outputs(raw):
     # first 4 bytes in each batch entry are boring.
     # Next 7432 are easy, policy extraction.
@@ -166,7 +143,7 @@ def main(cmd):
                          .shuffle(shuffle_size)\
                          .batch(split_batch_size).map(extract_inputs_outputs).prefetch(4)
     else:
-        train_parser = ChunkParser(FileDataSrc(train_chunks),
+        train_parser = ChunkParser(train_chunks,
                 shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE,
                 workers=train_workers)
         train_dataset = tf.data.Dataset.from_generator(
@@ -181,7 +158,7 @@ def main(cmd):
                          .shuffle(shuffle_size)\
                          .batch(split_batch_size).map(extract_inputs_outputs).prefetch(4)
     else:
-        test_parser = ChunkParser(FileDataSrc(test_chunks),
+        test_parser = ChunkParser(test_chunks,
                 shuffle_size=shuffle_size, sample=SKIP, batch_size=ChunkParser.BATCH_SIZE,
                 workers=test_workers)
         test_dataset = tf.data.Dataset.from_generator(
@@ -227,6 +204,6 @@ if __name__ == "__main__":
     argparser.add_argument('--output', type=str,
         help='file to store weights in')
 
-    mp.set_start_method('spawn')
+    #mp.set_start_method('spawn')
     main(argparser.parse_args())
     mp.freeze_support()


### PR DESCRIPTION
The current input data pipeline stores a copy of list of chunks for every reader process. Since by default there is only one game per chunk, with millions of chunks the list of filenames can take hundreds of MB of memory. When that is multiplied by number of reader processes it can take many GB.

This PR modifies the pipeline so that the list of files is stored only once and changes the multiprocessing start method from spawn to platform default (fork on Linux, spawn on Windows). fork start_method can reuse shared read only memory for each process further decreasing the memory consumption. I left it commented out for testing. There are some things that work differently with spawn and fork methods.

Script is included for shuffling and merging training data on disk. Using much larger chunks makes it possible to train from hard disk.

Also slightly unrelated change of making `virtual_batch_size` configurable in yaml. In my tests `virtual_batch_size` slightly loses strength and is slower to train. It wasn't tested when it was merged originally.

Some tests:

```
128x10 net with 2048 batch size, 1 split, half precision. RTX2080

SKIP, pipeline, virtual_batch_size, pos/s, GPU usage, memory
32, old, 64, -, -, OOM (>16G)
32, new (spawn), 64, 5531, 90, 13.9G
32, new (fork), 64, 5537, 90, 11.0G
32, new (fork), None, 6272, 60, 11.0G
1, new (fork), None, 8089, 80, 11.0G
```

This isn't still fast enough to fully use GPU on my PC. I think it's the single threaded `parse` function that is limiting the performance. Combining the chunk reading part of this and parsing part of the `experimental_v4_only_dataset` should result in much faster input pipeline.

I tested this on Linux, but it still needs testing on Windows before I'm comfortable with merging. @jjoshua2 ?