### PR TITLE
8 channels in moves left 1x1 convolution

### DIFF
--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -841,10 +841,10 @@ class TFProcess:
         # Moves left head
         if self.moves_left:
             conv_mov = self.conv_block_v2(flow, filter_size=1,
-                                       output_channels=4,
+                                       output_channels=8,
                                        name='moves_left')
             h_conv_mov_flat = tf.keras.layers.Flatten()(conv_mov)
-            h_fc4 = tf.keras.layers.Dense(512, kernel_initializer='glorot_normal', kernel_regularizer=self.l2reg, activation='relu', name='moves_left/dense1')(h_conv_mov_flat)
+            h_fc4 = tf.keras.layers.Dense(128, kernel_initializer='glorot_normal', kernel_regularizer=self.l2reg, activation='relu', name='moves_left/dense1')(h_conv_mov_flat)
 
             h_fc5 = tf.keras.layers.Dense(1, kernel_initializer='glorot_normal', kernel_regularizer=self.l2reg, activation='relu', name='moves_left/dense2')(h_fc4)
         else:


### PR DESCRIPTION
Having the number of convolution channels divisible by 8 is faster with cudnn-fp16 and doesn't seem to really affect the prediction performance. 128x10 net with 8 channels gets max 93k nps on backendbench and 4 gets 87k.