### PR TITLE
Needs protobuf in requirement.txt

### DIFF
--- a/tf/requirements.txt
+++ b/tf/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.13.3
 tensorflow==2.0.1
 tensorflow-tensorboard==0.4.0rc2
+protobuf==3.12.1


### PR DESCRIPTION
Adding protobuf 3.12.1 to the list of requirements for lczero-training (if I understand what I'm doing)