### PR TITLE
Add support for canonical v2.

### DIFF
--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -253,7 +253,7 @@ class ChunkParser:
                             self.flat_planes[0] + \
                             self.flat_planes[0] + \
                             self.flat_planes[stm]
-        elif input_format == 3 or input_format == 4 or input_format == 132:
+        elif input_format == 3 or input_format == 4 or input_format == 132 or input_format == 5 or input_format == 133:
             # Each inner array has to be reversed as these fields are in opposite endian to the planes data.
             them_ooo_bytes = reverse_expand_bits(them_ooo)
             us_ooo_bytes = reverse_expand_bits(us_ooo)
@@ -269,7 +269,7 @@ class ChunkParser:
         # Concatenate all byteplanes. Make the last plane all 1's so the NN can
         # detect edges of the board more easily
         aux_plus_6_plane = self.flat_planes[0]
-        if input_format == 132 and dep_ply_count >= 128:
+        if (input_format == 132 or input_format == 133) and dep_ply_count >= 128:
             aux_plus_6_plane = self.flat_planes[1]
         planes = planes.tobytes() + \
                  middle_planes + \

--- a/tf/net.py
+++ b/tf/net.py
@@ -10,6 +10,7 @@ LC0_MAJOR = 0
 LC0_MINOR = 21
 LC0_MINOR_WITH_INPUT_TYPE_3 = 25
 LC0_MINOR_WITH_INPUT_TYPE_4 = 26
+LC0_MINOR_WITH_INPUT_TYPE_5 = 27
 LC0_PATCH = 0
 WEIGHTS_MAGIC = 0x1c0
 
@@ -69,7 +70,9 @@ class Net:
 
     def set_input(self, input_format):
         self.pb.format.network_format.input = input_format
-        if input_format >= pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_HECTOPLIES:
+        if input_format == pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_V2 or input_format == pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_V2_ARMAGEDDON:
+            self.pb.min_version.minor = LC0_MINOR_WITH_INPUT_TYPE_5
+        elif input_format >= pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_HECTOPLIES:
             self.pb.min_version.minor = LC0_MINOR_WITH_INPUT_TYPE_4
         # Input type 2 was available before 3, but it was buggy, so also limit it to same version as 3.
         elif input_format != pb.NetworkFormat.INPUT_CLASSICAL_112_PLANE:

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -139,6 +139,10 @@ class TFProcess:
             self.INPUT_MODE = pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_HECTOPLIES
         elif input_mode == "canonical_armageddon":
             self.INPUT_MODE = pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_HECTOPLIES_ARMAGEDDON
+        elif input_mode == "canonical_v2":
+            self.INPUT_MODE = pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_V2
+        elif input_mode == "canonical_v2_armageddon":
+            self.INPUT_MODE = pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_V2_ARMAGEDDON
         else:
             raise ValueError(
                 "Unknown input mode format: {}".format(input_mode))

--- a/tf/train.py
+++ b/tf/train.py
@@ -336,9 +336,9 @@ def select_extractor(mode):
         return extract_inputs_outputs_if2
     if mode == 3:
         return extract_inputs_outputs_if3
-    if mode == 4:
+    if mode == 4 or mode == 5:
         return extract_inputs_outputs_if4
-    if mode == 132:
+    if mode == 132 or mode == 133:
         return extract_inputs_outputs_if132
     assert (false)
 


### PR DESCRIPTION
This is pretty trivial since the only difference to canonical hectoplies is in which history items are stored in the history planes. So can reuse the same extractors as for canonical hectoplies.