### PR TITLE
Improve value focus by having it done before general downsampling.

### DIFF
--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -416,7 +416,9 @@ class ChunkParser:
             return
 
         for i in range(0, len(chunkdata), record_size):
-            if version == V6_VERSION:
+            record = chunkdata[i:i + record_size]            
+            ## only unpack every position if value_focus is activated.
+            if self.value_focus_min < 1 and version == V6_VERSION:
                 # value focus code, peek at best_q and orig_q from record (unpacks as tuple with one item)
                 best_q = struct.unpack('f', record[8284:8288])[0]
                 orig_q = struct.unpack('f', record[8328:8332])[0]
@@ -426,7 +428,7 @@ class ChunkParser:
                     diff_q = abs(best_q - orig_q)
                     thresh_p = self.value_focus_min + self.value_focus_slope * diff_q
                     if thresh_p < 1.0 and random.random() > thresh_p:
-                        continue
+                        continue  # Skip this record
 
             if self.sample > 1:
                 # Downsample, using only 1/Nth of the items, taking into account the effects of value focus.
@@ -442,7 +444,6 @@ class ChunkParser:
                     if random.randint(0, self.sample - 1) != 0:
                         continue  # Skip this record.
 
-            record = chunkdata[i:i + record_size]
             # for earlier versions, append fake bytes to record to maintain size
             if version == V3_VERSION:
                 # add 16 bytes of fake root_q, best_q, root_d, best_d to match V4 format
@@ -455,7 +456,6 @@ class ChunkParser:
             if version == V3_VERSION or version == V4_VERSION or version == V5_VERSION:
                 # add 48 byes of fake result_q, result_d etc
                 record += 48 * b'\x00'
-
 
             yield record
 

--- a/tf/chunkparser.py
+++ b/tf/chunkparser.py
@@ -437,7 +437,7 @@ class ChunkParser:
                         keep_this_position_probability = 1 / (self.sample * self.value_focus_min)
                         if random.random() > keep_this_position_probability:
                             continue  # Skip this record
-                    else
+                else:
                     ## value_focus not activated
                     if random.randint(0, self.sample - 1) != 0:
                         continue  # Skip this record.


### PR DESCRIPTION
`SKIP=32` in `train.py` defines how many sequental positions to discard to avoid sampling over-correlated positions since they typically are from sequential positions in a game. (technically, SKIP is used to create a probability of inclusion, so there is no hard limit against sequential positions, they are just not likely to appear).

After discarding 31 out of 32 positions, `value_focus` discards further positions, especially positions where `orig_q` is very similar to eval after search (`best_q`). This patch does two things:

1. It reverses the order of these to downsampling mechanisms, so that `value_focus` sampling gets to see all positions (instead of only one position in 32).
2. It adjusts the downsampling implied by `SKIP=32`, so that the target sampling rate is 1 over `SKIP` when the downsampling performed by `value_focus` is accounted for.

Preliminary testing the idea rather than the implementation by hardcoding SKIP=1 and setting `value_focus_min` to 1/32 suggests this is an improvement.