### PR TITLE
Add support for mish activation for most cases of activation in network.

### DIFF
--- a/tf/net.py
+++ b/tf/net.py
@@ -11,6 +11,7 @@ LC0_MINOR = 21
 LC0_MINOR_WITH_INPUT_TYPE_3 = 25
 LC0_MINOR_WITH_INPUT_TYPE_4 = 26
 LC0_MINOR_WITH_INPUT_TYPE_5 = 27
+LC0_MINOR_WITH_MISH = 29
 LC0_PATCH = 0
 WEIGHTS_MAGIC = 0x1c0
 
@@ -49,6 +50,7 @@ class Net:
         self.set_policyformat(policy)
         self.set_valueformat(value)
         self.set_movesleftformat(moves_left)
+        self.set_defaultactivation(pb.NetworkFormat.DEFAULT_ACTIVATION_RELU)
 
     def set_networkformat(self, net):
         self.pb.format.network_format.network = net
@@ -77,6 +79,12 @@ class Net:
         # Input type 2 was available before 3, but it was buggy, so also limit it to same version as 3.
         elif input_format != pb.NetworkFormat.INPUT_CLASSICAL_112_PLANE:
             self.pb.min_version.minor = LC0_MINOR_WITH_INPUT_TYPE_3
+
+    def set_defaultactivation(self, activation):
+        self.pb.format.network_format.default_activation = activation
+        if activation == pb.NetworkFormat.DEFAULT_ACTIVATION_MISH:
+            if self.pb.min_version.minor < LC0_MINOR_WITH_MISH:
+                self.pb.min_version.minor = LC0_MINOR_WITH_MISH
 
     def get_weight_amounts(self):
         value_weights = 8

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -123,11 +123,13 @@ class TFProcess:
         value_head = self.cfg['model'].get('value', 'wdl')
         moves_left_head = self.cfg['model'].get('moves_left', 'v1')
         input_mode = self.cfg['model'].get('input_type', 'classic')
+        default_activation = self.cfg['model'].get('default_activation', 'relu')
 
         self.POLICY_HEAD = None
         self.VALUE_HEAD = None
         self.MOVES_LEFT_HEAD = None
         self.INPUT_MODE = None
+        self.DEFAULT_ACTIVATION = None
 
         if policy_head == "classical":
             self.POLICY_HEAD = pb.NetworkFormat.POLICY_CLASSICAL
@@ -182,6 +184,17 @@ class TFProcess:
                 "Unknown input mode format: {}".format(input_mode))
 
         self.net.set_input(self.INPUT_MODE)
+
+        if default_activation == "relu":
+            self.net.set_defaultactivation(pb.NetworkFormat.DEFAULT_ACTIVATION_RELU)
+            self.DEFAULT_ACTIVATION = 'relu'
+        elif:
+            self.net.set_defaultactivation(pb.NetworkFormat.DEFAULT_ACTIVATION_MISH)
+            import tensorflow_addons as tfa
+            self.DEFAULT_ACTIVATION = tfa.activations.mish
+        else:
+            raise ValueError(
+                "Unknown default activation type: {}".format(default_activation))
 
         self.swa_enabled = self.cfg['training'].get('swa', False)
 
@@ -1041,7 +1054,7 @@ class TFProcess:
 
         pooled = tf.keras.layers.GlobalAveragePooling2D(
             data_format='channels_first')(inputs)
-        squeezed = tf.keras.layers.Activation('relu')(tf.keras.layers.Dense(
+        squeezed = tf.keras.layers.Activation(self.DEFAULT_ACTIVATION)(tf.keras.layers.Dense(
             channels // self.SE_ratio,
             kernel_initializer='glorot_normal',
             kernel_regularizer=self.l2reg,
@@ -1066,7 +1079,7 @@ class TFProcess:
                                       kernel_regularizer=self.l2reg,
                                       data_format='channels_first',
                                       name=name + '/conv2d')(inputs)
-        return tf.keras.layers.Activation('relu')(self.batch_norm(
+        return tf.keras.layers.Activation(self.DEFAULT_ACTIVATION)(self.batch_norm(
             conv, name=name + '/bn', scale=bn_scale))
 
     def residual_block(self, inputs, channels, name):
@@ -1078,7 +1091,7 @@ class TFProcess:
                                        kernel_regularizer=self.l2reg,
                                        data_format='channels_first',
                                        name=name + '/1/conv2d')(inputs)
-        out1 = tf.keras.layers.Activation('relu')(self.batch_norm(conv1,
+        out1 = tf.keras.layers.Activation(self.DEFAULT_ACTIVATION)(self.batch_norm(conv1,
                                                                   name +
                                                                   '/1/bn',
                                                                   scale=False))
@@ -1095,7 +1108,7 @@ class TFProcess:
                                                        scale=True),
                                        channels,
                                        name=name + '/se')
-        return tf.keras.layers.Activation('relu')(tf.keras.layers.add(
+        return tf.keras.layers.Activation(self.DEFAULT_ACTIVATION)(tf.keras.layers.add(
             [inputs, out2]))
 
     def construct_net(self, inputs):
@@ -1150,7 +1163,7 @@ class TFProcess:
         h_fc2 = tf.keras.layers.Dense(128,
                                       kernel_initializer='glorot_normal',
                                       kernel_regularizer=self.l2reg,
-                                      activation='relu',
+                                      activation=self.DEFAULT_ACTIVATION,
                                       name='value/dense1')(h_conv_val_flat)
         if self.wdl:
             h_fc3 = tf.keras.layers.Dense(3,
@@ -1176,7 +1189,7 @@ class TFProcess:
                 128,
                 kernel_initializer='glorot_normal',
                 kernel_regularizer=self.l2reg,
-                activation='relu',
+                activation=self.DEFAULT_ACTIVATION,
                 name='moves_left/dense1')(h_conv_mov_flat)
 
             h_fc5 = tf.keras.layers.Dense(1,

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -188,7 +188,7 @@ class TFProcess:
         if default_activation == "relu":
             self.net.set_defaultactivation(pb.NetworkFormat.DEFAULT_ACTIVATION_RELU)
             self.DEFAULT_ACTIVATION = 'relu'
-        elif:
+        elif default_activation == "mish":
             self.net.set_defaultactivation(pb.NetworkFormat.DEFAULT_ACTIVATION_MISH)
             import tensorflow_addons as tfa
             self.DEFAULT_ACTIVATION = tfa.activations.mish


### PR DESCRIPTION
Requires the following added to NetworkFormat in net.proto
  // Activation used everywhere except head outputs or otherwise specified.
  enum DefaultActivation {
    DEFAULT_ACTIVATION_RELU = 0;
    DEFAULT_ACTIVATION_MISH = 1;
  }
  optional DefaultActivation default_activation = 7;
