### PR TITLE
bump numpy to 1.19.2

### DIFF
--- a/tf/requirements.txt
+++ b/tf/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.13.3
+numpy==1.19.2
 tensorflow==2.5.1
 tensorflow-tensorboard==0.4.0rc2
 protobuf==3.12.1


### PR DESCRIPTION
tensorflow==2.5.1 requires numpy==1.19.2 causing dependency resolution errors.