### PR TITLE
Implement Net-to-CoreML Conversion Script

### DIFF
--- a/tf/net_to_coreml.py
+++ b/tf/net_to_coreml.py
@@ -12,11 +12,16 @@ if __name__ == "__main__":
     # MODEL TO COREML
     input_shape = ct.Shape(shape=(1, 112, 8, 8))
 
+    # Set the compute precision
+    compute_precision = ct.precision.FLOAT16
+    # compute_precision = ct.precision.FLOAT32
+
     # Convert the model to CoreML
     coreml_model = ct.convert(
         tfp.model,
         convert_to="mlprogram",
         inputs=[ct.TensorType(shape=input_shape, name="input_1")],
+        compute_precision=compute_precision,
     )
 
     # Get the protobuf spec

--- a/tf/net_to_coreml.py
+++ b/tf/net_to_coreml.py
@@ -6,7 +6,7 @@ import coremltools as ct
 if __name__ == "__main__":
     ##############
     # NET TO MODEL
-    args, root_dir, tfp = convert(include_attn_wts_output=False)
+    args, root_dir, tfp = convert(include_attn_wts_output=False, rescale_rule50=False)
 
     #################
     # MODEL TO COREML
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     input_names = [input.name for input in spec.description.input]
 
     # Print the input names
-    print(f"Input names: {input_names}")
+    print(f"Renamed input: {input_names}")
 
     # Set output names
     output_names = ["output_policy", "output_value"]
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         ct.utils.rename_feature(spec, spec.description.output[i].name, name)
 
     # Print the output names
-    print(f"Output names: {[output_i.name for output_i in spec.description.output]}")
+    print(f"Renamed output: {[output_i.name for output_i in spec.description.output]}")
 
     # Set model description
     coreml_model.short_description = f"Lc0 converted from {args.net}"

--- a/tf/net_to_coreml.py
+++ b/tf/net_to_coreml.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     START_FROM = args.start
 
     tfp = tfprocess.TFProcess(cfg)
-    tfp.init_net()
+    tfp.init_net(include_attn_wts_output=False)
     tfp.replace_weights(args.net, args.ignore_errors)
     tfp.global_step.assign(START_FROM)
 

--- a/tf/net_to_coreml.py
+++ b/tf/net_to_coreml.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import yaml
+import tfprocess
+import coremltools as ct
+
+if __name__ == "__main__":
+    ##############
+    # NET TO MODEL
+    argparser = argparse.ArgumentParser(description="Convert net to coreml.")
+    argparser.add_argument(
+        "net", type=str, help="Net file to be converted to a model checkpoint."
+    )
+    argparser.add_argument(
+        "--start", type=int, default=0, help="Offset to set global_step to."
+    )
+    argparser.add_argument(
+        "--cfg",
+        type=argparse.FileType("r"),
+        help="yaml configuration with training parameters",
+    )
+    argparser.add_argument(
+        "-e",
+        "--ignore-errors",
+        action="store_true",
+        help="Ignore missing and wrong sized values.",
+    )
+    args = argparser.parse_args()
+    cfg = yaml.safe_load(args.cfg.read())
+    print(yaml.dump(cfg, default_flow_style=False))
+    START_FROM = args.start
+
+    tfp = tfprocess.TFProcess(cfg)
+    tfp.init_net()
+    tfp.replace_weights(args.net, args.ignore_errors)
+    tfp.global_step.assign(START_FROM)
+
+    root_dir = os.path.join(cfg["training"]["path"], cfg["name"])
+    if not os.path.exists(root_dir):
+        os.makedirs(root_dir)
+    tfp.manager.save(checkpoint_number=START_FROM)
+    print("Wrote model to {}".format(tfp.manager.latest_checkpoint))
+
+    #################
+    # MODEL TO COREML
+    input_shape = ct.Shape(shape=(1, 112, 8, 8))
+
+    # Convert the model to CoreML
+    coreml_model = ct.convert(
+        tfp.model,
+        convert_to="mlprogram",
+        inputs=[ct.TensorType(shape=input_shape, name="input_1")],
+    )
+
+    # Get the protobuf spec
+    spec = coreml_model._spec
+
+    # Rename the input
+    ct.utils.rename_feature(spec, "input_1", "input_planes")
+
+    # Get input names
+    input_names = [input.name for input in spec.description.input]
+
+    # Print the input names
+    print(f"Input names: {input_names}")
+
+    # Set output names
+    output_names = ["output_policy", "output_value"]
+
+    if tfp.moves_left:
+        output_names.append("output_moves_left")
+
+    # Rename output names
+    for i, name in enumerate(output_names):
+        # Rename the output
+        ct.utils.rename_feature(spec, spec.description.output[i].name, name)
+
+    # Print the output names
+    print(f"Output names: {[output_i.name for output_i in spec.description.output]}")
+
+    # Set model description
+    coreml_model.short_description = f"Lc0 converted from {args.net}"
+
+    # Rebuild the model with the updated spec
+    print(f"Rebuilding model with updated spec ...")
+    rebuilt_mlmodel = ct.models.MLModel(
+        coreml_model._spec, weights_dir=coreml_model._weights_dir
+    )
+
+    # Save the CoreML model
+    print(f"Saving model ...")
+    coreml_model_path = os.path.join(root_dir, f"{args.net}.mlpackage")
+    coreml_model.save(coreml_model_path)
+
+    print(f"CoreML model saved at {coreml_model_path}")

--- a/tf/net_to_coreml.py
+++ b/tf/net_to_coreml.py
@@ -1,46 +1,12 @@
 #!/usr/bin/env python3
-import argparse
 import os
-import yaml
-import tfprocess
+from net_to_model import convert
 import coremltools as ct
 
 if __name__ == "__main__":
     ##############
     # NET TO MODEL
-    argparser = argparse.ArgumentParser(description="Convert net to coreml.")
-    argparser.add_argument(
-        "net", type=str, help="Net file to be converted to a model checkpoint."
-    )
-    argparser.add_argument(
-        "--start", type=int, default=0, help="Offset to set global_step to."
-    )
-    argparser.add_argument(
-        "--cfg",
-        type=argparse.FileType("r"),
-        help="yaml configuration with training parameters",
-    )
-    argparser.add_argument(
-        "-e",
-        "--ignore-errors",
-        action="store_true",
-        help="Ignore missing and wrong sized values.",
-    )
-    args = argparser.parse_args()
-    cfg = yaml.safe_load(args.cfg.read())
-    print(yaml.dump(cfg, default_flow_style=False))
-    START_FROM = args.start
-
-    tfp = tfprocess.TFProcess(cfg)
-    tfp.init_net(include_attn_wts_output=False)
-    tfp.replace_weights(args.net, args.ignore_errors)
-    tfp.global_step.assign(START_FROM)
-
-    root_dir = os.path.join(cfg["training"]["path"], cfg["name"])
-    if not os.path.exists(root_dir):
-        os.makedirs(root_dir)
-    tfp.manager.save(checkpoint_number=START_FROM)
-    print("Wrote model to {}".format(tfp.manager.latest_checkpoint))
+    args, root_dir, tfp = convert(include_attn_wts_output=False)
 
     #################
     # MODEL TO COREML

--- a/tf/net_to_model.py
+++ b/tf/net_to_model.py
@@ -4,7 +4,7 @@ import os
 import yaml
 import tfprocess
 
-def convert(include_attn_wts_output=True):
+def convert(include_attn_wts_output=True, rescale_rule50=True):
     argparser = argparse.ArgumentParser(description='Convert net to model.')
     argparser.add_argument('net',
                         type=str,
@@ -27,7 +27,7 @@ def convert(include_attn_wts_output=True):
 
     tfp = tfprocess.TFProcess(cfg)
     tfp.init_net(include_attn_wts_output)
-    tfp.replace_weights(args.net, args.ignore_errors)
+    tfp.replace_weights(args.net, args.ignore_errors, rescale_rule50)
     tfp.global_step.assign(START_FROM)
 
     root_dir = os.path.join(cfg['training']['path'], cfg['name'])

--- a/tf/net_to_model.py
+++ b/tf/net_to_model.py
@@ -4,33 +4,38 @@ import os
 import yaml
 import tfprocess
 
-argparser = argparse.ArgumentParser(description='Convert net to model.')
-argparser.add_argument('net',
-                       type=str,
-                       help='Net file to be converted to a model checkpoint.')
-argparser.add_argument('--start',
-                       type=int,
-                       default=0,
-                       help='Offset to set global_step to.')
-argparser.add_argument('--cfg',
-                       type=argparse.FileType('r'),
-                       help='yaml configuration with training parameters')
-argparser.add_argument('-e',
-                       '--ignore-errors',
-                       action='store_true',
-                       help='Ignore missing and wrong sized values.')
-args = argparser.parse_args()
-cfg = yaml.safe_load(args.cfg.read())
-print(yaml.dump(cfg, default_flow_style=False))
-START_FROM = args.start
+def convert(include_attn_wts_output=True):
+    argparser = argparse.ArgumentParser(description='Convert net to model.')
+    argparser.add_argument('net',
+                        type=str,
+                        help='Net file to be converted to a model checkpoint.')
+    argparser.add_argument('--start',
+                        type=int,
+                        default=0,
+                        help='Offset to set global_step to.')
+    argparser.add_argument('--cfg',
+                        type=argparse.FileType('r'),
+                        help='yaml configuration with training parameters')
+    argparser.add_argument('-e',
+                        '--ignore-errors',
+                        action='store_true',
+                        help='Ignore missing and wrong sized values.')
+    args = argparser.parse_args()
+    cfg = yaml.safe_load(args.cfg.read())
+    print(yaml.dump(cfg, default_flow_style=False))
+    START_FROM = args.start
 
-tfp = tfprocess.TFProcess(cfg)
-tfp.init_net()
-tfp.replace_weights(args.net, args.ignore_errors)
-tfp.global_step.assign(START_FROM)
+    tfp = tfprocess.TFProcess(cfg)
+    tfp.init_net(include_attn_wts_output)
+    tfp.replace_weights(args.net, args.ignore_errors)
+    tfp.global_step.assign(START_FROM)
 
-root_dir = os.path.join(cfg['training']['path'], cfg['name'])
-if not os.path.exists(root_dir):
-    os.makedirs(root_dir)
-tfp.manager.save(checkpoint_number=START_FROM)
-print("Wrote model to {}".format(tfp.manager.latest_checkpoint))
+    root_dir = os.path.join(cfg['training']['path'], cfg['name'])
+    if not os.path.exists(root_dir):
+        os.makedirs(root_dir)
+    tfp.manager.save(checkpoint_number=START_FROM)
+    print("Wrote model to {}".format(tfp.manager.latest_checkpoint))
+    return args, root_dir, tfp
+
+if __name__ == "__main__":
+    convert()

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -377,10 +377,10 @@ class TFProcess:
         else:
             self.init_net()
 
-    def init_net(self):
+    def init_net(self, include_attn_wts_output=True):
         self.l2reg = tf.keras.regularizers.l2(l=0.5 * (0.0001))
         input_var = tf.keras.Input(shape=(112, 8, 8))
-        outputs = self.construct_net(input_var)
+        outputs = self.construct_net(input_var, include_attn_wts_output=include_attn_wts_output)
         self.model = tf.keras.Model(inputs=input_var, outputs=outputs)
 
         # swa_count initialized regardless to make checkpoint code simpler.
@@ -1520,7 +1520,7 @@ class TFProcess:
         h_fc1 = ApplyAttentionPolicyMap()(policy_attn_logits, promotion_logits)
         return h_fc1
 
-    def construct_net(self, inputs, name=''):
+    def construct_net(self, inputs, name='', include_attn_wts_output=True):
 
         if self.encoder_layers > 0:
             flow, attn_wts = self.create_encoder_body(inputs,
@@ -1665,9 +1665,11 @@ class TFProcess:
         # attention weights added as optional output for analysis -- ignored by backend
         if self.POLICY_HEAD == pb.NetworkFormat.POLICY_ATTENTION:
             if self.moves_left:
-                outputs = [h_fc1, h_fc3, h_fc5, attn_wts]
+                outputs = [h_fc1, h_fc3, h_fc5]
             else:
-                outputs = [h_fc1, h_fc3, attn_wts]
+                outputs = [h_fc1, h_fc3]
+            if include_attn_wts_output:
+                outputs.append(attn_wts)
         elif self.moves_left:
             outputs = [h_fc1, h_fc3, h_fc5]
         else:

--- a/tf/tfprocess.py
+++ b/tf/tfprocess.py
@@ -628,7 +628,7 @@ class TFProcess:
             keep_checkpoint_every_n_hours=24,
             checkpoint_name=self.cfg['name'])
 
-    def replace_weights(self, proto_filename, ignore_errors=False):
+    def replace_weights(self, proto_filename, ignore_errors=False, rescale_rule50=True):
         self.net.parse_proto(proto_filename)
 
         filters, blocks = self.net.filters(), self.net.blocks()
@@ -676,7 +676,7 @@ class TFProcess:
 
             if weight.shape.ndims == 4:
                 # Rescale rule50 related weights as clients do not normalize the input.
-                if weight.name == 'input/conv2d/kernel:0' and self.net.pb.format.network_format.input < pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_HECTOPLIES:
+                if rescale_rule50 and weight.name == 'input/conv2d/kernel:0' and self.net.pb.format.network_format.input < pb.NetworkFormat.INPUT_112_WITH_CANONICALIZATION_HECTOPLIES:
                     num_inputs = 112
                     # 50 move rule is the 110th input, or 109 starting from 0.
                     rule50_input = 109


### PR DESCRIPTION
This commit introduces the `net_to_coreml.py` script in the `tf/` directory. The script facilitates the conversion of a neural network file into a TensorFlow model, followed by its transformation into a CoreML model. This process mirrors the TensorFlow model conversion methodology used in `net_to_model.py`.

**Key features of the CoreML conversion include:**

- Setting the input shape to (1, 112, 8, 8).
- Defining `input_planes` as the input name.
- Specifying output names as `output_policy`, `output_value`, and `output_moves_left`.
- Assigning a concise description to the model, formatted as `Lc0 converted from {net name}`. The script concludes by saving the CoreML model as `{net name}.mlpackage`. This enhancement enables the conversion of neural networks into CoreML models, which can be executed using Apple's Neural Engine. Future development of the CoreML backend is planned within the `lc0` repository.

**Test 1: 128x10 (PASS)**
```
% python net_to_coreml.py --cfg 128x10.yaml-20210723-1032 weights_run2_744706.lc0          
TensorFlow version 2.15.0 has not been tested with coremltools. You may run into unexpected errors. TensorFlow 2.12.0 is the most recent version that has been tested.
dataset:
  allow_less_chunks: true
  input_test: dev2/test/
  input_train: dev2/train/
  input_validation: dev2/validate/
  num_chunks: 1000000
  train_ratio: 0.9
gpu: 0
model:
  filters: 128
  residual_blocks: 10
  se_ratio: 4
name: 128x10-t74
training:
  batch_size: 1024
  lr_boundaries:
  - 120
  lr_values:
  - 4.0e-05
  - 4.0e-05
  mask_legal_moves: true
  max_grad_norm: 5.4
  moves_left_loss_weight: 1.0
  num_batch_splits: 1
  num_test_positions: 40000
  path: dev2/networks
  policy_loss_weight: 1.0
  q_ratio: 0
  renorm: true
  renorm_max_d: 0.0
  renorm_max_r: 1.0
  shuffle_size: 500000
  swa: true
  swa_max_n: 10
  swa_output: true
  swa_steps: 100
  test_steps: 500
  total_steps: 2000
  train_avg_report_steps: 200
  validation_steps: 500
  value_focus_min: 1.0
  value_focus_slope: 0.0
  value_loss_weight: 2.0
  warmup_steps: 1000

[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]
Wrote model to dev2/networks/128x10-t74/128x10-t74-0
Running TensorFlow Graph Passes: 100%|█████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:00<00:00, 20.80 passes/s]
Converting TF Frontend ==> MIL Ops: 100%|██████████████████████████████████████████████████████████████████████████████████████| 413/413 [00:00<00:00, 11943.65 ops/s]
Running MIL frontend_tensorflow2 pipeline: 100%|█████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 1628.68 passes/s]
Running MIL default pipeline: 100%|██████████████████████████████████████████████████████████████████████████████████████████████| 71/71 [00:00<00:00, 86.30 passes/s]
Running MIL backend_mlprogram pipeline: 100%|██████████████████████████████████████████████████████████████████████████████████| 12/12 [00:00<00:00, 1404.81 passes/s]
Input names: ['input_planes']
Output names: ['output_policy', 'output_value', 'output_moves_left']
Rebuilding model with updated spec ...
Saving model ...
CoreML model saved at dev2/networks/128x10-t74/weights_run2_744706.lc0.mlpackage
```

**Test 2: 512x19 (FAILED)**
```
% python net_to_coreml.py --cfg 512x19-t80.yaml-20230507-0216 512x19-t81-swa-10061000.pb.gz
TensorFlow version 2.15.0 has not been tested with coremltools. You may run into unexpected errors. TensorFlow 2.12.0 is the most recent version that has been tested.
dataset:
  allow_less_chunks: true
  input_test:
  - dev1/test/
  input_train:
  - dev1/train/
  input_validation: dev1/validate/
  num_chunks: 3000000
  test_workers: 8
  train_ratio: 0.9
  train_workers: 32
gpu: 0
model:
  default_activation: mish
  filters: 512
  pol_encoder_layers: 0
  policy: attention
  residual_blocks: 19
  se_ratio: 16
name: 512x19-t80
training:
  batch_size: 1024
  checkpoint_steps: 4000
  diff_focus_min: 0.025
  diff_focus_slope: 3.0
  lookahead_optimizer: true
  lr_boundaries:
  - 100
  lr_values:
  - 0.0004
  - 0.0004
  mask_legal_moves: true
  max_grad_norm: 4.0
  moves_left_loss_weight: 1.0
  num_batch_splits: 2
  num_test_positions: 40000
  path: dev1/networks
  policy_loss_weight: 1.0
  q_ratio: 0.0
  reg_term_weight: 0.05
  renorm: true
  renorm_max_d: 0.0
  renorm_max_r: 1.0
  shuffle_size: 500000
  swa: true
  swa_max_n: 10
  swa_output: true
  swa_steps: 100
  test_steps: 500
  total_steps: 500
  train_avg_report_steps: 200
  validation_steps: 500
  value_loss_weight: 1.0
  warmup_steps: 1000

[PhysicalDevice(name='/physical_device:GPU:0', device_type='GPU')]
/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/tensorflow_addons/utils/tfa_eol_msg.py:23: UserWarning: 

TensorFlow Addons (TFA) has ended development and introduction of new features.
TFA has entered a minimal maintenance and release mode until a planned end of life in May 2024.
Please modify downstream libraries to take dependencies from other repositories in our TensorFlow community (e.g. Keras, Keras-CV, and Keras-NLP). 

For more information see: https://github.com/tensorflow/addons/issues/2807 

  warnings.warn(
Wrote model to dev1/networks/512x19-t80/512x19-t80-0
Running TensorFlow Graph Passes: 100%|█████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:00<00:00,  7.15 passes/s]
Converting TF Frontend ==> MIL Ops:  97%|███████████████████████████████████████████████████████████████████████████████████▍  | 960/989 [00:00<00:00, 11277.54 ops/s]
Traceback (most recent call last):
  File "/Users/chinchangyang/Code/lczero-training-ccy/tf/net_to_coreml.py", line 50, in <module>
    coreml_model = ct.convert(
                   ^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/_converters_entry.py", line 574, in convert
    mlmodel = mil_convert(
              ^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/converter.py", line 188, in mil_convert
    return _mil_convert(model, convert_from, convert_to, ConverterRegistry, MLModel, compute_units, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/converter.py", line 212, in _mil_convert
    proto, mil_program = mil_convert_to_proto(
                         ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/converter.py", line 286, in mil_convert_to_proto
    prog = frontend_converter(model, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/converter.py", line 98, in __call__
    return tf2_loader.load()
           ^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/frontend/tensorflow/load.py", line 82, in load
    program = self._program_from_tf_ssa()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/frontend/tensorflow2/load.py", line 210, in _program_from_tf_ssa
    return converter.convert()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/frontend/tensorflow/converter.py", line 522, in convert
    self.convert_main_graph(prog, graph)
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/frontend/tensorflow/converter.py", line 421, in convert_main_graph
    outputs = convert_graph(self.context, graph, self.output_names)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/frontend/tensorflow/convert_utils.py", line 191, in convert_graph
    add_op(context, node)
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/frontend/tensorflow/ops.py", line 1332, in RealDiv
    y = mb.cast(x=context[node.inputs[1]], dtype="fp32")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/ops/registry.py", line 182, in add_op
    return cls._add_op(op_cls_to_add, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/builder.py", line 184, in _add_op
    new_op.type_value_inference()
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/operation.py", line 260, in type_value_inference
    output_vals = self._auto_val(output_types)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/operation.py", line 377, in _auto_val
    vals = self.value_inference()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/operation.py", line 111, in wrapper
    return func(self)
           ^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py", line 868, in value_inference
    return self.get_cast_value(self.x, self.dtype.val)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/chinchangyang/miniconda3/envs/lczero-training-py3.11/lib/python3.11/site-packages/coremltools/converters/mil/mil/ops/defs/iOS15/elementwise_unary.py", line 894, in get_cast_value
    return input_var.val.astype(dtype=string_to_nptype(dtype_val))
           ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'float' object has no attribute 'astype'
```

The error message is similar with this issue. https://github.com/apple/coremltools/issues/1768