### PR TITLE
Export training_steps in network exports

### DIFF
--- a/src/lczero_training/commands/train.py
+++ b/src/lczero_training/commands/train.py
@@ -99,6 +99,7 @@ def train(config_filename: str) -> None:
             min_version="0.28",
             num_heads=training_state.num_heads,
             license=None,
+            training_steps=new_state.step,
         )
         export_state = (
             new_state.swa_state

--- a/src/lczero_training/daemon/pipeline.py
+++ b/src/lczero_training/daemon/pipeline.py
@@ -249,6 +249,7 @@ class TrainingPipeline:
             min_version="0.31",
             num_heads=self._training_state.num_heads,
             license=None,
+            training_steps=self._training_state.jit_state.step,
         )
         export_state = (
             self._training_state.jit_state.swa_state


### PR DESCRIPTION
Both the train command and daemon pipeline were missing the training_steps field when constructing LeelaExportOptions.