### PR TITLE
Improve data loading multi thread performance

### DIFF
--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -7,11 +7,9 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cerrno>
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
-#include <limits>
 #include <stdexcept>
 #include <unistd.h>
 
@@ -52,24 +50,12 @@ uint64_t ParseOctal(const std::array<uint8_t, 12>& octal) {
 }
 
 bool ReadExact(int fd, off_t offset, void* buffer, size_t size) {
-  if (offset < 0) return false;
-  if (size > static_cast<size_t>(std::numeric_limits<ssize_t>::max())) {
-    return false;
-  }
   char* out = static_cast<char*>(buffer);
   size_t read_total = 0;
   while (read_total < size) {
-    if (offset > std::numeric_limits<off_t>::max() -
-                     static_cast<off_t>(read_total)) {
-      return false;
-    }
     const ssize_t read_now =
         pread(fd, out + read_total, size - read_total, offset + read_total);
-    if (read_now < 0) {
-      if (errno == EINTR) continue;
-      return false;
-    }
-    if (read_now == 0) return false;
+    if (read_now <= 0) return false;
     read_total += static_cast<size_t>(read_now);
   }
   return true;
@@ -154,12 +140,10 @@ TarChunkSource::TarChunkSource(
 TarChunkSource::~TarChunkSource() { Close(); }
 
 void TarChunkSource::Close() {
-  if (fd_ >= 0) {
-    if (close(fd_) != 0) {
-      PLOG(WARNING) << "Failed to close tar file descriptor for " << path_;
-    }
-    fd_ = -1;
+  if (fd_ >= 0 && close(fd_) != 0) {
+    PLOG(WARNING) << "Failed to close tar file descriptor for " << path_;
   }
+  fd_ = -1;
 }
 
 std::string TarChunkSource::GetChunkSortKey() const { return filename_; }
@@ -193,18 +177,8 @@ void TarChunkSource::Index() {
     const std::filesystem::path filepath = std::filesystem::path(fname);
     const off_t file_offset = offset;
     const size_t size = ParseOctal(header.size);
-    const uint64_t padded_size =
-        ((static_cast<uint64_t>(size) + 511) / 512) * 512;
-    if (padded_size > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) ||
-        file_offset > std::numeric_limits<off_t>::max() -
-                          static_cast<off_t>(padded_size)) {
-      LOG(WARNING) << "Truncated tar file at " << fname
-                   << ", expected size: " << size
-                   << ", actual size: 0";
-      break;
-    }
-    const off_t new_offset = file_offset + static_cast<off_t>(padded_size);
-    offset = new_offset;
+    const size_t padded_size = ((size + 511) / 512) * 512;
+    offset = file_offset + static_cast<off_t>(padded_size);
 
     if (filepath.filename() == "LICENSE") continue;
     files_.push_back({file_offset, size, filepath.extension() == ".gz"});

--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -7,8 +7,13 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cerrno>
 #include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <limits>
 #include <stdexcept>
+#include <unistd.h>
 
 #include "trainingdata/trainingdata_v6.h"
 #include "utils/gz.h"
@@ -46,13 +51,33 @@ uint64_t ParseOctal(const std::array<uint8_t, 12>& octal) {
   return value;
 }
 
-std::optional<std::string> ReadGzipPrefix(FILE* file, long int offset,
-                                          long int size, size_t max_bytes) {
-  if (max_bytes == 0) return std::string();
-
-  if (fseek(file, offset, SEEK_SET) != 0) {
-    return std::nullopt;
+bool ReadExact(int fd, off_t offset, void* buffer, size_t size) {
+  if (offset < 0) return false;
+  if (size > static_cast<size_t>(std::numeric_limits<ssize_t>::max())) {
+    return false;
   }
+  char* out = static_cast<char*>(buffer);
+  size_t read_total = 0;
+  while (read_total < size) {
+    if (offset > std::numeric_limits<off_t>::max() -
+                     static_cast<off_t>(read_total)) {
+      return false;
+    }
+    const ssize_t read_now =
+        pread(fd, out + read_total, size - read_total, offset + read_total);
+    if (read_now < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (read_now == 0) return false;
+    read_total += static_cast<size_t>(read_now);
+  }
+  return true;
+}
+
+std::optional<std::string> ReadGzipPrefix(int fd, off_t offset, size_t size,
+                                          size_t max_bytes) {
+  if (max_bytes == 0) return std::string();
 
   z_stream strm = {};
   if (inflateInit2(&strm, 16 + MAX_WBITS) != Z_OK) {
@@ -66,21 +91,21 @@ std::optional<std::string> ReadGzipPrefix(FILE* file, long int offset,
   std::string output;
   output.reserve(std::min<size_t>(max_bytes, kChunkSize));
 
-  long int remaining = size;
+  size_t remaining = size;
+  off_t current_offset = offset;
   bool finished = false;
 
   while (remaining > 0 && !finished && output.size() < max_bytes) {
-    const size_t to_read = static_cast<size_t>(
-        std::min<long int>(remaining, static_cast<long int>(kChunkSize)));
-    const size_t read = fread(input_buffer.data(), 1, to_read, file);
-    if (read != to_read) {
+    const size_t to_read = std::min(remaining, kChunkSize);
+    if (!ReadExact(fd, current_offset, input_buffer.data(), to_read)) {
       inflateEnd(&strm);
       return std::nullopt;
     }
-    remaining -= static_cast<long int>(read);
+    remaining -= to_read;
+    current_offset += static_cast<off_t>(to_read);
 
     strm.next_in = reinterpret_cast<Bytef*>(input_buffer.data());
-    strm.avail_in = static_cast<uInt>(read);
+    strm.avail_in = static_cast<uInt>(to_read);
 
     while (strm.avail_in > 0 && output.size() < max_bytes) {
       strm.next_out = reinterpret_cast<Bytef*>(output_buffer.data());
@@ -113,16 +138,28 @@ std::optional<std::string> ReadGzipPrefix(FILE* file, long int offset,
 TarChunkSource::TarChunkSource(
     const std::filesystem::path& filename,
     ChunkSourceLoaderConfig::FrameFormat frame_format)
-    : file_(fopen(filename.string().c_str(), "rb")),
+    : path_(filename),
       filename_(filename.filename().string()),
       frame_format_(frame_format) {
-  if (!file_) throw std::runtime_error("Failed to open tar file");
+  fd_ = open(path_.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd_ < 0) {
+    throw std::runtime_error(
+        absl::StrCat("Failed to open tar file: ", path_.string(), ": ",
+                     std::strerror(errno)));
+  }
   // Perform indexing during construction.
   Index();
 }
 
-TarChunkSource::~TarChunkSource() {
-  if (file_) fclose(file_);
+TarChunkSource::~TarChunkSource() { Close(); }
+
+void TarChunkSource::Close() {
+  if (fd_ >= 0) {
+    if (close(fd_) != 0) {
+      PLOG(WARNING) << "Failed to close tar file descriptor for " << path_;
+    }
+    fd_ = -1;
+  }
 }
 
 std::string TarChunkSource::GetChunkSortKey() const { return filename_; }
@@ -130,12 +167,15 @@ std::string TarChunkSource::GetChunkSortKey() const { return filename_; }
 void TarChunkSource::Index() {
   assert(files_.empty());
 
+  off_t offset = 0;
+
   while (true) {
     TarHeader header;
-    if (fread(&header, sizeof(header), 1, file_) != 1) {
+    if (!ReadExact(fd_, offset, &header, sizeof(header))) {
       LOG(WARNING) << "Truncated tar file: " << filename_;
       break;
     }
+    offset += sizeof(header);
 
     if (header.name[0] == '\0') break;  // End of file.
 
@@ -151,19 +191,23 @@ void TarChunkSource::Index() {
 
     std::string_view fname(const_cast<const char*>(header.name.data()));
     const std::filesystem::path filepath = std::filesystem::path(fname);
-    const long int offset = ftell(file_);
-    const long int size = ParseOctal(header.size);
-    const long int new_offset = offset + (size + 511) / 512 * 512;
-    fseek(file_, new_offset, SEEK_SET);
-    if (new_offset != ftell(file_)) {
+    const off_t file_offset = offset;
+    const size_t size = ParseOctal(header.size);
+    const uint64_t padded_size =
+        ((static_cast<uint64_t>(size) + 511) / 512) * 512;
+    if (padded_size > static_cast<uint64_t>(std::numeric_limits<off_t>::max()) ||
+        file_offset > std::numeric_limits<off_t>::max() -
+                          static_cast<off_t>(padded_size)) {
       LOG(WARNING) << "Truncated tar file at " << fname
                    << ", expected size: " << size
-                   << ", actual size: " << (new_offset - offset);
+                   << ", actual size: 0";
       break;
     }
+    const off_t new_offset = file_offset + static_cast<off_t>(padded_size);
+    offset = new_offset;
 
     if (filepath.filename() == "LICENSE") continue;
-    files_.push_back({offset, size, filepath.extension() == ".gz"});
+    files_.push_back({file_offset, size, filepath.extension() == ".gz"});
   }
 
   LOG(INFO) << "Read " << files_.size() << " entries from " << filename_;
@@ -178,8 +222,9 @@ std::optional<std::vector<FrameType>> TarChunkSource::GetChunkData(
   }
   const auto& file_entry = files_[index];
   std::string content(file_entry.size, '\0');
-  fseek(file_, file_entry.offset, SEEK_SET);
-  fread(content.data(), 1, file_entry.size, file_);
+  if (!ReadExact(fd_, file_entry.offset, content.data(), file_entry.size)) {
+    return std::nullopt;
+  }
   if (file_entry.is_gzip) {
     try {
       content = GunzipBuffer(content);
@@ -222,17 +267,12 @@ std::optional<std::string> TarChunkSource::GetChunkPrefix(size_t index,
   }
   const auto& file_entry = files_[index];
   if (file_entry.is_gzip) {
-    return ReadGzipPrefix(file_, file_entry.offset, file_entry.size, max_bytes);
+    return ReadGzipPrefix(fd_, file_entry.offset, file_entry.size, max_bytes);
   }
 
-  const size_t to_read =
-      std::min(static_cast<size_t>(file_entry.size), max_bytes);
+  const size_t to_read = std::min(file_entry.size, max_bytes);
   std::string content(to_read, '\0');
-  if (fseek(file_, file_entry.offset, SEEK_SET) != 0) {
-    return std::nullopt;
-  }
-  const size_t read = fread(content.data(), 1, to_read, file_);
-  if (read != to_read) {
+  if (!ReadExact(fd_, file_entry.offset, content.data(), to_read)) {
     return std::nullopt;
   }
   return content;

--- a/csrc/loader/chunk_source/tar_chunk_source.h
+++ b/csrc/loader/chunk_source/tar_chunk_source.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/types.h>
+
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -26,13 +28,16 @@ class TarChunkSource : public ChunkSource {
   // Performs one-time indexing during construction. Not part of the interface.
   void Index();
   struct FileEntry {
-    long int offset;
-    long int size;
+    off_t offset;
+    size_t size;
     bool is_gzip;
   };
 
-  FILE* file_ = nullptr;
+  void Close();
+
+  int fd_ = -1;
   std::vector<FileEntry> files_;
+  std::filesystem::path path_;
   std::string filename_;
   ChunkSourceLoaderConfig::FrameFormat frame_format_;
 };

--- a/csrc/loader/stages/shuffling_chunk_pool.cc
+++ b/csrc/loader/stages/shuffling_chunk_pool.cc
@@ -265,22 +265,22 @@ void ShufflingChunkPool::ProcessInputFiles(
     std::for_each(uninitialized_sources.rbegin(), uninitialized_sources.rend(),
                   [this, &start_chunk_index](auto& source) {
                     const size_t count = source->GetChunkCount();
-                    chunk_sources_.push_back(
-                        {.start_chunk_index = start_chunk_index,
-                         .source = std::move(source),
-                         .dropped_chunks = {},
-                         .use_counts = std::vector<uint16_t>(count, 0),
-                         .weight = std::vector<float>(count, -1.0f),
-                         .cache = std::vector<std::unique_ptr<CacheNode>>(
-                             cachehit_output_queue_.has_value() ? count : 0)});
+                    auto item = std::make_shared<ChunkSourceItem>();
+                    item->start_chunk_index = start_chunk_index;
+                    item->source = std::move(source);
+                    item->use_counts = std::vector<uint16_t>(count, 0);
+                    item->weight = std::vector<float>(count, -1.0f);
+                    item->cache = std::vector<std::unique_ptr<CacheNode>>(
+                        cachehit_output_queue_.has_value() ? count : 0);
+                    chunk_sources_.push_back(std::move(item));
                     start_chunk_index +=
-                        chunk_sources_.back().source->GetChunkCount();
+                        chunk_sources_.back()->source->GetChunkCount();
                   });
 
     // Initialize stream shuffler with the initial bounds.
     if (!chunk_sources_.empty()) {
-      size_t total_chunks = chunk_sources_.back().start_chunk_index +
-                            chunk_sources_.back().source->GetChunkCount();
+      size_t total_chunks = chunk_sources_.back()->start_chunk_index +
+                            chunk_sources_.back()->source->GetChunkCount();
       // Set bounds to provide the last chunk_pool_size_ chunks.
       size_t lower_bound =
           total_chunks > chunk_pool_size_ ? total_chunks - chunk_pool_size_ : 0;
@@ -301,10 +301,10 @@ void ShufflingChunkPool::ProcessInputFiles(
     LOG(INFO) << "Current anchor: '" << anchor_ << "'";
 
     absl::MutexLock sources_lock(&chunk_sources_mutex_);
-    std::vector<const ChunkSourceItem*> sources_after_anchor;
+    std::vector<std::shared_ptr<ChunkSourceItem>> sources_after_anchor;
     for (const auto& item : chunk_sources_) {
-      if (item.source->GetChunkSortKey() > anchor_) {
-        sources_after_anchor.push_back(&item);
+      if (item->source->GetChunkSortKey() > anchor_) {
+        sources_after_anchor.push_back(item);
       }
     }
 
@@ -401,37 +401,44 @@ void ShufflingChunkPool::CachingWorker(std::stop_token stop_token,
         return cache_request_queue_->Get(stop_token);
       }();
 
-      absl::MutexLock lock(&chunk_sources_mutex_);
+      std::shared_ptr<ChunkSourceItem> source_item;
+      float max_weight = 0.0f;
+      size_t local_index = 0;
+      {
+        absl::MutexLock lock(&chunk_sources_mutex_);
 
-      // Find the chunk source containing this global index.
-      auto it = absl::c_lower_bound(
-          chunk_sources_, cache_request.global_index,
-          [](const auto& source_item, size_t chunk_idx) {
-            return source_item.start_chunk_index +
-                       source_item.source->GetChunkCount() <=
-                   chunk_idx;
-          });
+        // Find the chunk source containing this global index.
+        auto it = absl::c_lower_bound(
+            chunk_sources_, cache_request.global_index,
+            [](const auto& item, size_t chunk_idx) {
+              return item->start_chunk_index + item->source->GetChunkCount() <=
+                     chunk_idx;
+            });
 
-      if (it == chunk_sources_.end() ||
-          cache_request.global_index < it->start_chunk_index) {
-        chunk_source_not_found_.fetch_add(1, std::memory_order_acq_rel);
-        continue;
+        if (it == chunk_sources_.end() ||
+            cache_request.global_index < (*it)->start_chunk_index) {
+          chunk_source_not_found_.fetch_add(1, std::memory_order_acq_rel);
+          continue;
+        }
+
+        source_item = *it;
+        max_weight = max_weight_;
+        local_index = cache_request.global_index - source_item->start_chunk_index;
       }
 
-      const size_t local_index =
-          cache_request.global_index - it->start_chunk_index;
-      assert(local_index < it->use_counts.size());
+      absl::MutexLock item_lock(&source_item->mutex);
+      assert(local_index < source_item->use_counts.size());
 
       // Check use_count match.
-      if (it->use_counts[local_index] != cache_request.next_use) {
+      if (source_item->use_counts[local_index] != cache_request.next_use) {
         mismatched_use_counts_.fetch_add(1, std::memory_order_acq_rel);
         continue;
       }
 
       // Compute how many positions to cache.
-      const float weight = it->weight[local_index];
+      const float weight = source_item->weight[local_index];
       assert(weight >= 0.0f);
-      const double probability = ComputeHanseProbability(weight);
+      const double probability = ComputeHanseProbability(weight, max_weight);
       exponential_avg_probability =
           exponential_avg_probability * (1.0 - kTheta) + probability * kTheta;
       const double n = (probability * config_.position_cache_size() /
@@ -440,7 +447,7 @@ void ShufflingChunkPool::CachingWorker(std::stop_token stop_token,
       reminder = n - std::floor(n);
       const size_t positions_to_cache = static_cast<size_t>(std::floor(n));
       // Traverse and extend the cache chain.
-      std::unique_ptr<CacheNode>* current = &it->cache[local_index];
+      std::unique_ptr<CacheNode>* current = &source_item->cache[local_index];
       for (size_t i = 0; i < positions_to_cache; ++i) {
         if (*current) {
           current = &(*current)->next;
@@ -474,33 +481,29 @@ struct ShufflingChunkPool::ChunkData {
   size_t local_index = 0;
   size_t global_index = 0;
   uint32_t use_count = 0;
-  ChunkSourceItem* source_item = nullptr;
+  std::shared_ptr<ChunkSourceItem> source_item;
 };
 
 std::optional<std::variant<TrainingChunk, FrameType>>
 ShufflingChunkPool::GetNextChunkData() {
   while (true) {
     ChunkData chunk_data;
-    ChunkStatus status;
+    const ChunkStatus status = GetChunkInfo(chunk_data);
+    if (status == ChunkStatus::kEnd) return std::nullopt;
+    if (status == ChunkStatus::kRetry) continue;
+
+    const bool hanse_enabled = config_.hanse_sampling_threshold() > 0;
+    if (hanse_enabled && !HanseAccept(chunk_data)) continue;
+
     {
-      absl::MutexLock lock(&chunk_sources_mutex_);
-      status = GetChunkInfo(chunk_data);
-      if (status == ChunkStatus::kEnd) return std::nullopt;
-      if (status == ChunkStatus::kRetry) continue;
+      absl::MutexLock lock(&chunk_data.source_item->mutex);
 
-      const bool hanse_enabled = config_.hanse_sampling_threshold() > 0;
-      if (hanse_enabled && !HanseAccept(chunk_data)) continue;
-
-      // Increment use_count for this chunk.
-      assert(chunk_data.source_item->use_counts.size() >
-             chunk_data.local_index);
+      assert(chunk_data.source_item->use_counts.size() > chunk_data.local_index);
       chunk_data.use_count =
           chunk_data.source_item->use_counts[chunk_data.local_index]++;
 
-      // Check cache if configured.
       if (cachehit_output_queue_.has_value()) {
-        auto& cache_chain =
-            chunk_data.source_item->cache[chunk_data.local_index];
+        auto& cache_chain = chunk_data.source_item->cache[chunk_data.local_index];
         if (cache_chain) {
           cache_hits_.fetch_add(1, std::memory_order_acq_rel);
           cached_positions_.fetch_sub(1, std::memory_order_acq_rel);
@@ -510,11 +513,9 @@ ShufflingChunkPool::GetNextChunkData() {
         }
         cache_misses_.fetch_add(1, std::memory_order_acq_rel);
       }
-
-      if (chunk_data.data.empty()) {
-        if (!LoadChunkData(chunk_data)) continue;
-      }
     }
+
+    if (chunk_data.data.empty() && !LoadChunkData(chunk_data)) continue;
 
     TrainingChunk chunk;
     chunk.sort_key = std::move(chunk_data.sort_key);
@@ -532,6 +533,7 @@ bool ShufflingChunkPool::LoadChunkData(ChunkData& chunk_data) {
       chunk_data.source_item->source->GetChunkData(chunk_data.local_index);
 
   if (!data || data->empty()) {
+    absl::MutexLock lock(&chunk_data.source_item->mutex);
     chunk_data.source_item->dropped_chunks.insert(chunk_data.local_index);
     dropped_chunks_metric_.fetch_add(1, std::memory_order_acq_rel);
     return false;
@@ -543,55 +545,64 @@ bool ShufflingChunkPool::LoadChunkData(ChunkData& chunk_data) {
 
 ShufflingChunkPool::ChunkStatus ShufflingChunkPool::GetChunkInfo(
     ChunkData& out_chunk_data) {
-  std::optional<size_t> chunk_index = stream_shuffler_.GetNextItem();
+  std::shared_ptr<ChunkSourceItem> source_item;
+  {
+    absl::MutexLock lock(&chunk_sources_mutex_);
+    std::optional<size_t> chunk_index = stream_shuffler_.GetNextItem();
 
-  if (!chunk_index && !chunk_sources_.empty()) {
-    size_t total_chunks = chunk_sources_.back().start_chunk_index +
-                          chunk_sources_.back().source->GetChunkCount();
-    size_t lower_bound = total_chunks > chunk_pool_size_
-                             ? total_chunks - chunk_pool_size_
-                             : chunk_sources_.front().start_chunk_index;
-    stream_shuffler_.Reset(lower_bound, total_chunks);
-    reshuffles_.fetch_add(1, std::memory_order_acq_rel);
-    chunk_index = stream_shuffler_.GetNextItem();
+    if (!chunk_index && !chunk_sources_.empty()) {
+      size_t total_chunks = chunk_sources_.back()->start_chunk_index +
+                            chunk_sources_.back()->source->GetChunkCount();
+      size_t lower_bound = total_chunks > chunk_pool_size_
+                               ? total_chunks - chunk_pool_size_
+                               : chunk_sources_.front()->start_chunk_index;
+      stream_shuffler_.Reset(lower_bound, total_chunks);
+      reshuffles_.fetch_add(1, std::memory_order_acq_rel);
+      chunk_index = stream_shuffler_.GetNextItem();
+    }
+
+    if (!chunk_index) return ChunkStatus::kEnd;
+
+    auto it =
+        absl::c_lower_bound(chunk_sources_, *chunk_index,
+                            [](const auto& item, size_t chunk_idx) {
+                              return item->start_chunk_index +
+                                         item->source->GetChunkCount() <=
+                                     chunk_idx;
+                            });
+
+    if (ABSL_PREDICT_FALSE(it == chunk_sources_.end() ||
+                           *chunk_index < (*it)->start_chunk_index)) {
+      LOG(WARNING) << "Chunk index " << *chunk_index
+                   << " out of range for available chunk sources.";
+      return ChunkStatus::kRetry;
+    }
+
+    source_item = *it;
+    out_chunk_data.local_index = *chunk_index - source_item->start_chunk_index;
+    out_chunk_data.sort_key = source_item->source->GetChunkSortKey();
+    out_chunk_data.global_index = *chunk_index;
   }
 
-  if (!chunk_index) return ChunkStatus::kEnd;
-
-  auto it =
-      absl::c_lower_bound(chunk_sources_, *chunk_index,
-                          [](const auto& source_item, size_t chunk_idx) {
-                            return source_item.start_chunk_index +
-                                       source_item.source->GetChunkCount() <=
-                                   chunk_idx;
-                          });
-
-  if (ABSL_PREDICT_FALSE(it == chunk_sources_.end() ||
-                         *chunk_index < it->start_chunk_index)) {
-    LOG(WARNING) << "Chunk index " << *chunk_index
-                 << " out of range for available chunk sources.";
-    return ChunkStatus::kRetry;
+  {
+    absl::MutexLock lock(&source_item->mutex);
+    if (source_item->dropped_chunks.contains(out_chunk_data.local_index)) {
+      return ChunkStatus::kRetry;
+    }
   }
 
-  out_chunk_data.local_index = *chunk_index - it->start_chunk_index;
-  if (it->dropped_chunks.contains(out_chunk_data.local_index)) {
-    return ChunkStatus::kRetry;
-  }
-
-  out_chunk_data.source_item = &(*it);
-  out_chunk_data.sort_key = it->source->GetChunkSortKey();
-  out_chunk_data.global_index = *chunk_index;
-
+  out_chunk_data.source_item = std::move(source_item);
   return ChunkStatus::kOk;
 }
 
-double ShufflingChunkPool::ComputeHanseProbability(float weight) {
-  if (max_weight_ <= 0.0f) return 1.0;
-  return std::pow(weight / max_weight_, config_.hanse_sampling_gamma());
+double ShufflingChunkPool::ComputeHanseProbability(float weight,
+                                                   float max_weight) const {
+  if (max_weight <= 0.0f) return 1.0;
+  return std::pow(weight / max_weight, config_.hanse_sampling_gamma());
 }
 
 float ShufflingChunkPool::ComputeChunkWeight(
-    absl::Span<const FrameType> frames) {
+    absl::Span<const FrameType> frames) const {
   return absl::c_accumulate(frames, 0.0f, [this](float sum, const auto& frame) {
     return sum +
            ComputePositionSamplingWeight(frame, config_.position_sampling());
@@ -600,21 +611,42 @@ float ShufflingChunkPool::ComputeChunkWeight(
 
 bool ShufflingChunkPool::HanseAccept(ChunkData& chunk_data) {
   assert(chunk_data.source_item);
-  assert(chunk_data.source_item->weight.size() > chunk_data.local_index);
+  float weight = -1.0f;
+  {
+    absl::MutexLock lock(&chunk_data.source_item->mutex);
+    assert(chunk_data.source_item->weight.size() > chunk_data.local_index);
+    weight = chunk_data.source_item->weight[chunk_data.local_index];
+  }
 
-  if (chunk_data.source_item->weight[chunk_data.local_index] < 0.0f) {
+  if (weight < 0.0f) {
+    if (chunk_data.data.empty() && !LoadChunkData(chunk_data)) return false;
+    weight = ComputeChunkWeight(chunk_data.data);
+    {
+      absl::MutexLock pool_lock(&chunk_sources_mutex_);
+      max_weight_ = std::max(max_weight_, weight);
+      AddSample(chunk_weight_stats_, static_cast<double>(weight));
+    }
+    {
+      absl::MutexLock lock(&chunk_data.source_item->mutex);
+      const float cached_weight =
+          chunk_data.source_item->weight[chunk_data.local_index];
+      if (cached_weight < 0.0f) {
+        chunk_data.source_item->weight[chunk_data.local_index] = weight;
+      } else {
+        weight = cached_weight;
+      }
+    }
     hanse_cache_misses_.fetch_add(1, std::memory_order_acq_rel);
-    if (!LoadChunkData(chunk_data)) return false;
-    const float weight = ComputeChunkWeight(chunk_data.data);
-    chunk_data.source_item->weight[chunk_data.local_index] = weight;
-    max_weight_ = std::max(max_weight_, weight);
-    AddSample(chunk_weight_stats_, static_cast<double>(weight));
   } else {
     hanse_cache_hits_.fetch_add(1, std::memory_order_acq_rel);
   }
 
-  const double p = ComputeHanseProbability(
-      chunk_data.source_item->weight[chunk_data.local_index]);
+  float max_weight = 0.0f;
+  {
+    absl::MutexLock lock(&chunk_sources_mutex_);
+    max_weight = max_weight_;
+  }
+  const double p = ComputeHanseProbability(weight, max_weight);
   const double u = absl::Uniform<double>(bitgen_, 0.0, 1.0);
   if (u >= p) {
     hanse_rejected_.fetch_add(1, std::memory_order_acq_rel);
@@ -630,27 +662,29 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
   if (!chunk_sources_.empty()) {
     const auto& last_source = chunk_sources_.back();
     old_upper_bound =
-        last_source.start_chunk_index + last_source.source->GetChunkCount();
+        last_source->start_chunk_index + last_source->source->GetChunkCount();
   }
 
   size_t count = source->GetChunkCount();
-  chunk_sources_.push_back(
-      {.start_chunk_index = old_upper_bound,
-       .source = std::move(source),
-       .dropped_chunks = {},
-       .use_counts = std::vector<uint16_t>(count, 0),
-       .weight = std::vector<float>(count, -1.0f),
-       .cache = std::vector<std::unique_ptr<CacheNode>>(
-           cachehit_output_queue_.has_value() ? count : 0)});
+  auto item = std::make_shared<ChunkSourceItem>();
+  item->start_chunk_index = old_upper_bound;
+  item->source = std::move(source);
+  item->use_counts = std::vector<uint16_t>(count, 0);
+  item->weight = std::vector<float>(count, -1.0f);
+  item->cache =
+      std::vector<std::unique_ptr<CacheNode>>(cachehit_output_queue_.has_value()
+                                                  ? count
+                                                  : 0);
+  chunk_sources_.push_back(std::move(item));
 
   // Calculate current window bounds.
-  size_t new_upper_bound = chunk_sources_.back().start_chunk_index +
-                           chunk_sources_.back().source->GetChunkCount();
+  size_t new_upper_bound = chunk_sources_.back()->start_chunk_index +
+                           chunk_sources_.back()->source->GetChunkCount();
 
   // Remove old chunks if window exceeds chunk_pool_size_.
   while (!chunk_sources_.empty() && chunk_sources_.size() > 1) {
-    size_t window_start = chunk_sources_.front().start_chunk_index +
-                          chunk_sources_.front().source->GetChunkCount();
+    size_t window_start = chunk_sources_.front()->start_chunk_index +
+                          chunk_sources_.front()->source->GetChunkCount();
     size_t window_size = new_upper_bound - window_start;
 
     if (window_size < chunk_pool_size_) break;
@@ -658,7 +692,8 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
     // Count cached positions in the evicted source.
     if (cachehit_output_queue_.has_value()) {
       size_t evicted_cached = 0;
-      for (const auto& cache_chain : chunk_sources_.front().cache) {
+      absl::MutexLock item_lock(&chunk_sources_.front()->mutex);
+      for (const auto& cache_chain : chunk_sources_.front()->cache) {
         const CacheNode* node = cache_chain.get();
         while (node) {
           ++evicted_cached;
@@ -673,7 +708,7 @@ void ShufflingChunkPool::AddNewChunkSource(std::unique_ptr<ChunkSource> source)
   }
 
   // Update stream shuffler bounds with the sliding window.
-  size_t window_start = chunk_sources_.front().start_chunk_index;
+  size_t window_start = chunk_sources_.front()->start_chunk_index;
   size_t new_lower_bound = new_upper_bound > chunk_pool_size_
                                ? new_upper_bound - chunk_pool_size_
                                : window_start;
@@ -712,8 +747,8 @@ StageMetricProto ShufflingChunkPool::FlushMetrics() {
     if (!chunk_sources_.empty()) {
       const auto& first = chunk_sources_.front();
       const auto& last = chunk_sources_.back();
-      upper = last.start_chunk_index + last.source->GetChunkCount();
-      current = upper - first.start_chunk_index;
+      upper = last->start_chunk_index + last->source->GetChunkCount();
+      current = upper - first->start_chunk_index;
     }
 
     auto* current_chunks_metric = stage_metric.add_gauge_metrics();
@@ -832,7 +867,7 @@ std::pair<std::string, int> ShufflingChunkPool::ResetAnchor() {
     return {anchor_, previous_count};
   }
 
-  anchor_ = chunk_sources_.back().source->GetChunkSortKey();
+  anchor_ = chunk_sources_.back()->source->GetChunkSortKey();
   int previous_count = chunks_since_anchor_.exchange(0);
   return {anchor_, previous_count};
 }

--- a/csrc/loader/stages/shuffling_chunk_pool.h
+++ b/csrc/loader/stages/shuffling_chunk_pool.h
@@ -62,13 +62,14 @@ class ShufflingChunkPool : public Stage {
   };
 
   struct ChunkSourceItem {
+    mutable absl::Mutex mutex;
     size_t start_chunk_index;
     std::unique_ptr<ChunkSource> source;
-    absl::flat_hash_set<size_t> dropped_chunks;
+    absl::flat_hash_set<size_t> dropped_chunks ABSL_GUARDED_BY(mutex);
     // Per-chunk counters and cached weights.
-    std::vector<uint16_t> use_counts;
-    std::vector<float> weight;
-    std::vector<std::unique_ptr<CacheNode>> cache;
+    std::vector<uint16_t> use_counts ABSL_GUARDED_BY(mutex);
+    std::vector<float> weight ABSL_GUARDED_BY(mutex);
+    std::vector<std::unique_ptr<CacheNode>> cache ABSL_GUARDED_BY(mutex);
   };
 
   struct SourceIngestionThreadContext {
@@ -93,20 +94,16 @@ class ShufflingChunkPool : public Stage {
   void CachingWorker(std::stop_token stop_token, CachingThreadContext* context);
   void AddNewChunkSource(std::unique_ptr<ChunkSource> source)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  std::optional<std::variant<TrainingChunk, FrameType>> GetNextChunkData()
-      ABSL_LOCKS_EXCLUDED(chunk_sources_mutex_);
+  std::optional<std::variant<TrainingChunk, FrameType>> GetNextChunkData();
 
   enum class ChunkStatus { kOk, kRetry, kEnd };
   struct ChunkData;
 
-  ChunkStatus GetChunkInfo(ChunkData& out_chunk_data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  bool LoadChunkData(ChunkData& chunk_data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  bool HanseAccept(ChunkData& chunk_data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(chunk_sources_mutex_);
-  float ComputeChunkWeight(absl::Span<const FrameType> frames);
-  double ComputeHanseProbability(float weight);
+  ChunkStatus GetChunkInfo(ChunkData& out_chunk_data);
+  bool LoadChunkData(ChunkData& chunk_data);
+  bool HanseAccept(ChunkData& chunk_data);
+  float ComputeChunkWeight(absl::Span<const FrameType> frames) const;
+  double ComputeHanseProbability(float weight, float max_weight) const;
 
   Queue<ChunkSourceWithPhase>* primary_input_queue_ = nullptr;
   Queue<CacheRequest>* cache_request_queue_ = nullptr;
@@ -126,7 +123,7 @@ class ShufflingChunkPool : public Stage {
   std::atomic<int64_t> dropped_chunks_metric_{0};
 
   absl::Mutex chunk_sources_mutex_;
-  std::deque<ChunkSourceItem> chunk_sources_
+  std::deque<std::shared_ptr<ChunkSourceItem>> chunk_sources_
       ABSL_GUARDED_BY(chunk_sources_mutex_);
   StreamShuffler stream_shuffler_ ABSL_GUARDED_BY(chunk_sources_mutex_);
   float max_weight_ ABSL_GUARDED_BY(chunk_sources_mutex_) = 0.0f;

--- a/src/lczero_training/training/training.py
+++ b/src/lczero_training/training/training.py
@@ -304,6 +304,7 @@ class Training:
         if self._dp_sharding is not None:
             replicated = jshard.NamedSharding(self._dp_sharding.mesh, P())
             jit_state = jax.device_put(jit_state, replicated)
+        batch = self._validate_and_prepare_batch(next(datagen))
         for local_step in range(num_steps):
             logger.info(f"Starting step {jit_state.step}")
             if memory_profile_dir is not None:
@@ -312,10 +313,12 @@ class Training:
                     f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
                     f"_before_{int(jit_state.step)}.prof"
                 )
-            batch = self._validate_and_prepare_batch(next(datagen))
             jit_state, metrics = self.train_step(
                 self.optimizer_tx, jit_state, batch
             )
+            next_batch = None
+            if local_step + 1 < num_steps:
+                next_batch = self._validate_and_prepare_batch(next(datagen))
             step_value = int(
                 np.asarray(jax.device_get(jit_state.step)).reshape(())
             )
@@ -326,4 +329,6 @@ class Training:
                 step_hook, step_value, local_step, num_steps, metrics, jit_state
             )
             self._log_step_metrics(step_value, local_step, num_steps, metrics)
+            if next_batch is not None:
+                batch = next_batch
         return jit_state

--- a/src/lczero_training/training/training.py
+++ b/src/lczero_training/training/training.py
@@ -304,7 +304,6 @@ class Training:
         if self._dp_sharding is not None:
             replicated = jshard.NamedSharding(self._dp_sharding.mesh, P())
             jit_state = jax.device_put(jit_state, replicated)
-        batch = self._validate_and_prepare_batch(next(datagen))
         for local_step in range(num_steps):
             logger.info(f"Starting step {jit_state.step}")
             if memory_profile_dir is not None:
@@ -313,12 +312,10 @@ class Training:
                     f"{datetime.now().strftime('%Y%m%d-%H%M%S')}"
                     f"_before_{int(jit_state.step)}.prof"
                 )
+            batch = self._validate_and_prepare_batch(next(datagen))
             jit_state, metrics = self.train_step(
                 self.optimizer_tx, jit_state, batch
             )
-            next_batch = None
-            if local_step + 1 < num_steps:
-                next_batch = self._validate_and_prepare_batch(next(datagen))
             step_value = int(
                 np.asarray(jax.device_get(jit_state.step)).reshape(())
             )
@@ -329,6 +326,4 @@ class Training:
                 step_hook, step_value, local_step, num_steps, metrics, jit_state
             )
             self._log_step_metrics(step_value, local_step, num_steps, metrics)
-            if next_batch is not None:
-                batch = next_batch
         return jit_state


### PR DESCRIPTION
This PR combines two improvements to the data loading pipeline:
1. Moves mutex protection to the file source level in the tar chunk reader to reduce contention and improve thread safety when reading from multiple files concurrently.
2. Adds batch prefetching in the Python training loop to overlap data preparation with computation, improving training throughput. (tested only a few seconds faster per 5k steps)
Additionally, the C++ chunk source loader was modernized to use file descriptors with pread() for thread-safe reading, replaced FILE* usage, added proper mutex protection for shared data structures, and used shared_ptr for better lifetime management across threads. These changes collectively improve the performance and reliability of the data loading system.