### PR TITLE
Fix tar header parsing

### DIFF
--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -167,7 +167,10 @@ void TarChunkSource::Index() {
       case '5':  // Directory
         continue;
       case '0':  // Regular file
+      case '\0':  // Regular file (old format)
         break;
+      case 'x':  // Extended header
+        continue;
       default:
         LOG(WARNING) << "Unsupported tar header type: " << header.typeflag;
         continue;

--- a/csrc/loader/chunk_source/tar_chunk_source.cc
+++ b/csrc/loader/chunk_source/tar_chunk_source.cc
@@ -170,6 +170,7 @@ void TarChunkSource::Index() {
       case '\0':  // Regular file (old format)
         break;
       case 'x':  // Extended header
+        offset += static_cast<off_t>((ParseOctal(header.size) + 511) & ~511ULL);
         continue;
       default:
         LOG(WARNING) << "Unsupported tar header type: " << header.typeflag;


### PR DESCRIPTION
Regular files can have two different types. It looks like old format is used when combined with extended header.